### PR TITLE
Feat : runtime connector switching

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,7 +1,7 @@
 #-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
 # Here Comes user defined gitignore
 .mcp.json
-PLAN.md
+PLAN*.md
 AGENTS.md
 CLAUDE.md
 

--- a/README.md
+++ b/README.md
@@ -155,6 +155,7 @@ Open Chat Playground (OCP) is a web UI that is able to connect virtually any LLM
 1. Make sure you are at the repository root.
 
     ```bash
+    REPOSITORY_ROOT=$(git rev-parse --show-toplevel)
     cd $REPOSITORY_ROOT
     ```
 

--- a/src/OpenChat.PlaygroundApp/Abstractions/IChatClientFactory.cs
+++ b/src/OpenChat.PlaygroundApp/Abstractions/IChatClientFactory.cs
@@ -1,0 +1,43 @@
+using Microsoft.Extensions.AI;
+
+using OpenChat.PlaygroundApp.Connectors;
+using OpenChat.PlaygroundApp.Contracts;
+
+namespace OpenChat.PlaygroundApp.Abstractions;
+
+/// <summary>
+/// This provides interfaces to the chat client factory.
+/// </summary>
+public interface IChatClientFactory
+{
+    /// <summary>
+    /// Gets or creates a chat client for the specified connector type.
+    /// Uses lazy loading - creates IChatClient only on first request.
+    /// </summary>
+    Task<IChatClient> GetOrCreateChatClientAsync(ConnectorType type, CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Gets the cached chat client if available, null otherwise.
+    /// </summary>
+    IChatClient? GetCachedChatClient(ConnectorType type);
+
+    /// <summary>
+    /// Gets all connector information with their current states.
+    /// </summary>
+    IEnumerable<ConnectorInfo> GetAllConnectors();
+
+    /// <summary>
+    /// Gets only Ready or Active connectors.
+    /// </summary>
+    IEnumerable<ConnectorInfo> GetAvailableConnectors();
+
+    /// <summary>
+    /// Gets the state of a specific connector.
+    /// </summary>
+    ConnectorState GetConnectorState(ConnectorType type);
+
+    /// <summary>
+    /// Gets the error message for a failed connector.
+    /// </summary>
+    string? GetConnectorError(ConnectorType type);
+}

--- a/src/OpenChat.PlaygroundApp/Abstractions/IConnectorStateManager.cs
+++ b/src/OpenChat.PlaygroundApp/Abstractions/IConnectorStateManager.cs
@@ -1,0 +1,36 @@
+using Microsoft.Extensions.AI;
+
+using OpenChat.PlaygroundApp.Connectors;
+
+namespace OpenChat.PlaygroundApp.Abstractions;
+
+/// <summary>
+/// This provides interfaces to manage connector state per Blazor circuit.
+/// </summary>
+public interface IConnectorStateManager
+{
+    /// <summary>
+    /// Gets the current connector type.
+    /// </summary>
+    ConnectorType CurrentConnectorType { get; }
+
+    /// <summary>
+    /// Gets the current chat client, null if not yet initialized.
+    /// </summary>
+    IChatClient? CurrentChatClient { get; }
+
+    /// <summary>
+    /// Event raised when the connector changes.
+    /// </summary>
+    event EventHandler<ConnectorType>? OnConnectorChanged;
+
+    /// <summary>
+    /// Ensures the state manager is initialized with the default connector.
+    /// </summary>
+    Task EnsureInitializedAsync(CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Switches to a different connector (lazy loads IChatClient).
+    /// </summary>
+    Task SwitchConnectorAsync(ConnectorType type, CancellationToken cancellationToken = default);
+}

--- a/src/OpenChat.PlaygroundApp/Abstractions/IConnectorStateManager.cs
+++ b/src/OpenChat.PlaygroundApp/Abstractions/IConnectorStateManager.cs
@@ -20,9 +20,20 @@ public interface IConnectorStateManager
     IChatClient? CurrentChatClient { get; }
 
     /// <summary>
+    /// Gets whether a connector switch is currently in progress.
+    /// While this is true, chat requests should be blocked.
+    /// </summary>
+    bool IsSwitching { get; }
+
+    /// <summary>
     /// Event raised when the connector changes.
     /// </summary>
     event EventHandler<ConnectorType>? OnConnectorChanged;
+
+    /// <summary>
+    /// Event raised when the switching state changes.
+    /// </summary>
+    event EventHandler<bool>? OnSwitchingStateChanged;
 
     /// <summary>
     /// Ensures the state manager is initialized with the default connector.

--- a/src/OpenChat.PlaygroundApp/Components/Pages/Chat/Chat.razor
+++ b/src/OpenChat.PlaygroundApp/Components/Pages/Chat/Chat.razor
@@ -2,6 +2,10 @@
 
 <PageTitle>OpenChat Playground</PageTitle>
 
+<div class="chat-header">
+    <ConnectorSelector />
+</div>
+
 <ChatHeader OnNewChat="@ResetConversationAsync" />
 
 <ChatMessageList Messages="@messages" InProgressMessage="@currentResponseMessage">

--- a/src/OpenChat.PlaygroundApp/Components/Pages/Chat/Chat.razor
+++ b/src/OpenChat.PlaygroundApp/Components/Pages/Chat/Chat.razor
@@ -15,6 +15,6 @@
 </ChatMessageList>
 
 <div class="chat-container">
-    <ChatInput OnSend="@AddUserMessageAsync" @ref="@chatInput" />
+    <ChatInput OnSend="@AddUserMessageAsync" Disabled="@IsInputDisabled" @ref="@chatInput" />
     <SurveyPrompt /> @* Remove this line to eliminate the template survey message *@
 </div>

--- a/src/OpenChat.PlaygroundApp/Components/Pages/Chat/Chat.razor.cs
+++ b/src/OpenChat.PlaygroundApp/Components/Pages/Chat/Chat.razor.cs
@@ -1,11 +1,14 @@
 using Microsoft.AspNetCore.Components;
 using Microsoft.Extensions.AI;
 
+using OpenChat.PlaygroundApp.Abstractions;
 using OpenChat.PlaygroundApp.Services;
 
 namespace OpenChat.PlaygroundApp.Components.Pages.Chat;
 
+#pragma warning disable IDISP025 // Class with no virtual dispose method should be sealed - Blazor partial class cannot be sealed
 public partial class Chat : ComponentBase, IDisposable
+#pragma warning restore IDISP025
 {
     private const string SystemPrompt = @"
         You are an assistant who answers questions about anything.
@@ -21,13 +24,19 @@ public partial class Chat : ComponentBase, IDisposable
 
     [Inject]
     public required IChatService ChatService { get; set; }
-    
+
     [Inject]
     public required NavigationManager Nav { get; set; }
 
-    protected override void OnInitialized()
+    [Inject]
+    public required IConnectorStateManager ConnectorStateManager { get; set; }
+
+    protected override async Task OnInitializedAsync()
     {
         messages.Add(new(ChatRole.System, SystemPrompt));
+
+        // Initialize with default connector
+        await ConnectorStateManager.EnsureInitializedAsync();
     }
 
     private async Task AddUserMessageAsync(ChatMessage userMessage)

--- a/src/OpenChat.PlaygroundApp/Components/Pages/Chat/Chat.razor.cs
+++ b/src/OpenChat.PlaygroundApp/Components/Pages/Chat/Chat.razor.cs
@@ -21,6 +21,7 @@ public partial class Chat : ComponentBase, IDisposable
     private CancellationTokenSource? currentResponseCancellation;
     private ChatMessage? currentResponseMessage;
     private ChatInput? chatInput;
+    private bool isSwitchingConnector;
 
     [Inject]
     public required IChatService ChatService { get; set; }
@@ -31,9 +32,17 @@ public partial class Chat : ComponentBase, IDisposable
     [Inject]
     public required IConnectorStateManager ConnectorStateManager { get; set; }
 
+    /// <summary>
+    /// Gets whether the chat input should be disabled.
+    /// </summary>
+    public bool IsInputDisabled => isSwitchingConnector;
+
     protected override async Task OnInitializedAsync()
     {
         messages.Add(new(ChatRole.System, SystemPrompt));
+
+        // Subscribe to switching state changes
+        ConnectorStateManager.OnSwitchingStateChanged += HandleSwitchingStateChanged;
 
         // Initialize with default connector
         await ConnectorStateManager.EnsureInitializedAsync();
@@ -86,6 +95,15 @@ public partial class Chat : ComponentBase, IDisposable
         await chatInput!.FocusAsync();
     }
 
+    private void HandleSwitchingStateChanged(object? sender, bool isSwitching)
+    {
+        isSwitchingConnector = isSwitching;
+        InvokeAsync(StateHasChanged);
+    }
+
     public void Dispose()
-        => currentResponseCancellation?.Cancel();
+    {
+        currentResponseCancellation?.Cancel();
+        ConnectorStateManager.OnSwitchingStateChanged -= HandleSwitchingStateChanged;
+    }
 }

--- a/src/OpenChat.PlaygroundApp/Components/Pages/Chat/ChatInput.razor
+++ b/src/OpenChat.PlaygroundApp/Components/Pages/Chat/ChatInput.razor
@@ -1,9 +1,9 @@
 <EditForm Model="@this" OnValidSubmit="@SendMessageAsync">
     <label class="input-box page-width">
-        <textarea aria-label="User Message Textarea" @ref="@textArea" @bind="@messageText" @bind:event="oninput" @onkeydown="HandleKeyDown" placeholder="Type your message..." rows="1"></textarea>
+        <textarea aria-label="User Message Textarea" @ref="@textArea" @bind="@messageText" @bind:event="oninput" @onkeydown="HandleKeyDown" placeholder="@(Disabled ? "Switching connector..." : "Type your message...")" rows="1" disabled="@Disabled"></textarea>
 
         <div class="tools">
-            <button type="submit" title="Send" class="send-button" aria-label="User Message Send Button" disabled="@(string.IsNullOrWhiteSpace(messageText))">
+            <button type="submit" title="Send" class="send-button" aria-label="User Message Send Button" disabled="@(Disabled || string.IsNullOrWhiteSpace(messageText))">
                 <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" class="tool-icon">
                     <path stroke-linecap="round" stroke-linejoin="round" d="M6 12 3.269 3.125A59.769 59.769 0 0 1 21.485 12 59.768 59.768 0 0 1 3.27 20.875L5.999 12Zm0 0h7.5" />
                 </svg>

--- a/src/OpenChat.PlaygroundApp/Components/Pages/Chat/ChatInput.razor.cs
+++ b/src/OpenChat.PlaygroundApp/Components/Pages/Chat/ChatInput.razor.cs
@@ -13,6 +13,9 @@ public partial class ChatInput : ComponentBase
     [Parameter]
     public EventCallback<ChatMessage> OnSend { get; set; }
 
+    [Parameter]
+    public bool Disabled { get; set; }
+
     [Inject]
     public required IJSRuntime JS { get; set; }
 
@@ -21,6 +24,12 @@ public partial class ChatInput : ComponentBase
 
     private async Task SendMessageAsync()
     {
+        // Block sending when disabled (e.g., during connector switching)
+        if (Disabled)
+        {
+            return;
+        }
+
         if (messageText is { Length: > 0 } rawText)
         {
             var trimmedText = rawText.Trim();

--- a/src/OpenChat.PlaygroundApp/Components/Pages/Chat/ConnectorSelector.razor
+++ b/src/OpenChat.PlaygroundApp/Components/Pages/Chat/ConnectorSelector.razor
@@ -1,0 +1,55 @@
+@namespace OpenChat.PlaygroundApp.Components.Pages.Chat
+@using OpenChat.PlaygroundApp.Connectors
+
+<div class="connector-selector">
+    <label for="connector-select">Connector:</label>
+    <select id="connector-select"
+            @bind="SelectedConnector"
+            @bind:after="OnConnectorChangedAsync"
+            disabled="@IsLoading">
+        @foreach (var connector in Connectors)
+        {
+            <option value="@connector.Type"
+                    disabled="@(connector.State == ConnectorState.NotConfigured || connector.State == ConnectorState.Failed)">
+                @connector.Name
+                @if (connector.State == ConnectorState.NotConfigured)
+                {
+                    @(" (Not Configured)")
+                }
+                else if (connector.State == ConnectorState.Failed)
+                {
+                    @(" (Failed)")
+                }
+                else if (connector.State == ConnectorState.Active)
+                {
+                    @(" ●")
+                }
+            </option>
+        }
+    </select>
+    @if (IsLoading)
+    {
+        <span class="loading-spinner">Switching...</span>
+    }
+    @if (!string.IsNullOrEmpty(ErrorMessage))
+    {
+        <span class="error-message">@ErrorMessage</span>
+    }
+</div>
+
+<style>
+    .connector-selector {
+        display: flex;
+        align-items: center;
+        gap: 8px;
+        padding: 8px;
+    }
+    .loading-spinner {
+        color: #666;
+        font-style: italic;
+    }
+    .error-message {
+        color: red;
+        font-size: 0.9em;
+    }
+</style>

--- a/src/OpenChat.PlaygroundApp/Components/Pages/Chat/ConnectorSelector.razor.cs
+++ b/src/OpenChat.PlaygroundApp/Components/Pages/Chat/ConnectorSelector.razor.cs
@@ -31,7 +31,9 @@ public partial class ConnectorSelector : ComponentBase, IDisposable
     {
         Connectors = Factory.GetAllConnectors();
         SelectedConnector = StateManager.CurrentConnectorType;
+        IsLoading = StateManager.IsSwitching;
         StateManager.OnConnectorChanged += HandleConnectorChanged;
+        StateManager.OnSwitchingStateChanged += HandleSwitchingStateChanged;
     }
 
     private async Task OnConnectorChangedAsync()
@@ -70,8 +72,15 @@ public partial class ConnectorSelector : ComponentBase, IDisposable
         InvokeAsync(StateHasChanged);
     }
 
+    private void HandleSwitchingStateChanged(object? sender, bool isSwitching)
+    {
+        IsLoading = isSwitching;
+        InvokeAsync(StateHasChanged);
+    }
+
     public void Dispose()
     {
         StateManager.OnConnectorChanged -= HandleConnectorChanged;
+        StateManager.OnSwitchingStateChanged -= HandleSwitchingStateChanged;
     }
 }

--- a/src/OpenChat.PlaygroundApp/Components/Pages/Chat/ConnectorSelector.razor.cs
+++ b/src/OpenChat.PlaygroundApp/Components/Pages/Chat/ConnectorSelector.razor.cs
@@ -1,0 +1,77 @@
+using Microsoft.AspNetCore.Components;
+
+using OpenChat.PlaygroundApp.Abstractions;
+using OpenChat.PlaygroundApp.Connectors;
+using OpenChat.PlaygroundApp.Contracts;
+
+namespace OpenChat.PlaygroundApp.Components.Pages.Chat;
+
+/// <summary>
+/// This represents the connector selector component entity.
+/// </summary>
+#pragma warning disable IDISP025 // Class with no virtual dispose method should be sealed - Blazor partial class cannot be sealed
+public partial class ConnectorSelector : ComponentBase, IDisposable
+#pragma warning restore IDISP025
+{
+    [Inject]
+    public required IChatClientFactory Factory { get; set; }
+
+    [Inject]
+    public required IConnectorStateManager StateManager { get; set; }
+
+    [Inject]
+    public required ILogger<ConnectorSelector> Logger { get; set; }
+
+    private IEnumerable<ConnectorInfo> Connectors { get; set; } = [];
+    private ConnectorType SelectedConnector { get; set; }
+    private bool IsLoading { get; set; }
+    private string? ErrorMessage { get; set; }
+
+    protected override void OnInitialized()
+    {
+        Connectors = Factory.GetAllConnectors();
+        SelectedConnector = StateManager.CurrentConnectorType;
+        StateManager.OnConnectorChanged += HandleConnectorChanged;
+    }
+
+    private async Task OnConnectorChangedAsync()
+    {
+        if (SelectedConnector == StateManager.CurrentConnectorType)
+        {
+            return;
+        }
+
+        IsLoading = true;
+        ErrorMessage = null;
+
+        try
+        {
+            await StateManager.SwitchConnectorAsync(SelectedConnector);
+            // Refresh connector states
+            Connectors = Factory.GetAllConnectors();
+        }
+        catch (Exception ex)
+        {
+            Logger.LogError(ex, "Failed to switch connector to {Type}", SelectedConnector);
+            ErrorMessage = ex.Message;
+            // Revert selection
+            SelectedConnector = StateManager.CurrentConnectorType;
+        }
+        finally
+        {
+            IsLoading = false;
+        }
+    }
+
+    private void HandleConnectorChanged(object? sender, ConnectorType type)
+    {
+        SelectedConnector = type;
+        Connectors = Factory.GetAllConnectors();
+        InvokeAsync(StateHasChanged);
+    }
+
+    public void Dispose()
+    {
+        StateManager.OnConnectorChanged -= HandleConnectorChanged;
+    }
+}

--- a/src/OpenChat.PlaygroundApp/Connectors/ConnectorState.cs
+++ b/src/OpenChat.PlaygroundApp/Connectors/ConnectorState.cs
@@ -1,0 +1,27 @@
+namespace OpenChat.PlaygroundApp.Connectors;
+
+/// <summary>
+/// Represents the state of a connector.
+/// </summary>
+public enum ConnectorState
+{
+    /// <summary>
+    /// Required settings are missing in appsettings.json.
+    /// </summary>
+    NotConfigured,
+
+    /// <summary>
+    /// Settings validated, ready to be activated (IChatClient not yet created).
+    /// </summary>
+    Ready,
+
+    /// <summary>
+    /// Currently active with IChatClient created and cached.
+    /// </summary>
+    Active,
+
+    /// <summary>
+    /// Initialization was attempted but failed.
+    /// </summary>
+    Failed
+}

--- a/src/OpenChat.PlaygroundApp/Contracts/ConnectorInfo.cs
+++ b/src/OpenChat.PlaygroundApp/Contracts/ConnectorInfo.cs
@@ -1,0 +1,13 @@
+using OpenChat.PlaygroundApp.Connectors;
+
+namespace OpenChat.PlaygroundApp.Contracts;
+
+/// <summary>
+/// Represents information about a connector.
+/// </summary>
+public record ConnectorInfo(
+    ConnectorType Type,
+    string Name,
+    ConnectorState State,
+    string? ErrorMessage,
+    bool IsCurrentlyActive);

--- a/src/OpenChat.PlaygroundApp/Contracts/ConnectorStatusResponse.cs
+++ b/src/OpenChat.PlaygroundApp/Contracts/ConnectorStatusResponse.cs
@@ -1,0 +1,12 @@
+using OpenChat.PlaygroundApp.Connectors;
+
+namespace OpenChat.PlaygroundApp.Contracts;
+
+/// <summary>
+/// Response after connector status check or switch.
+/// </summary>
+public record ConnectorStatusResponse(
+    ConnectorType CurrentConnector,
+    ConnectorState State,
+    bool SwitchSuccessful,
+    string? ErrorMessage = null);

--- a/src/OpenChat.PlaygroundApp/Contracts/SwitchConnectorRequest.cs
+++ b/src/OpenChat.PlaygroundApp/Contracts/SwitchConnectorRequest.cs
@@ -1,0 +1,8 @@
+using OpenChat.PlaygroundApp.Connectors;
+
+namespace OpenChat.PlaygroundApp.Contracts;
+
+/// <summary>
+/// Request to switch to a different connector.
+/// </summary>
+public record SwitchConnectorRequest(ConnectorType ConnectorType);

--- a/src/OpenChat.PlaygroundApp/Endpoints/ConnectorEndpoint.cs
+++ b/src/OpenChat.PlaygroundApp/Endpoints/ConnectorEndpoint.cs
@@ -1,0 +1,105 @@
+using OpenChat.PlaygroundApp.Abstractions;
+using OpenChat.PlaygroundApp.Connectors;
+using OpenChat.PlaygroundApp.Contracts;
+
+namespace OpenChat.PlaygroundApp.Endpoints;
+
+/// <summary>
+/// This represents the connector API endpoint entity.
+/// </summary>
+public class ConnectorEndpoint(
+    IChatClientFactory factory,
+    ILogger<ConnectorEndpoint> logger) : IEndpoint
+{
+    private readonly IChatClientFactory _factory = factory ?? throw new ArgumentNullException(nameof(factory));
+    private readonly ILogger<ConnectorEndpoint> _logger = logger ?? throw new ArgumentNullException(nameof(logger));
+
+    /// <inheritdoc />
+    public void MapEndpoint(IEndpointRouteBuilder app)
+    {
+        app.MapGet("/connectors", GetConnectorsAsync)
+           .WithTags("Connectors")
+           .Produces<List<ConnectorInfo>>(StatusCodes.Status200OK, "application/json")
+           .WithName("GetConnectors")
+           .AddOpenApiOperationTransformer((operation, context, token) =>
+           {
+               operation.Summary = "Get all available connectors";
+               operation.Description = "Returns a list of all 12+ LLM connectors with their configuration status.";
+               return Task.CompletedTask;
+           });
+
+        app.MapGet("/connectors/current", GetCurrentConnectorAsync)
+           .WithTags("Connectors")
+           .Produces<ConnectorStatusResponse>(StatusCodes.Status200OK, "application/json")
+           .WithName("GetCurrentConnector")
+           .AddOpenApiOperationTransformer((operation, context, token) =>
+           {
+               operation.Summary = "Get current active connector";
+               operation.Description = "Returns the currently active connector for this circuit/session.";
+               return Task.CompletedTask;
+           });
+
+        app.MapPost("/connectors/switch", SwitchConnectorAsync)
+           .WithTags("Connectors")
+           .Accepts<SwitchConnectorRequest>("application/json")
+           .Produces<ConnectorStatusResponse>(StatusCodes.Status200OK, "application/json")
+           .Produces(StatusCodes.Status400BadRequest)
+           .WithName("SwitchConnector")
+           .AddOpenApiOperationTransformer((operation, context, token) =>
+           {
+               operation.Summary = "Switch to a different connector";
+               operation.Description = "Changes the active LLM connector. First switch may take 1-5 seconds (lazy loading).";
+               return Task.CompletedTask;
+           });
+    }
+
+    private IResult GetConnectorsAsync()
+    {
+        var connectors = _factory.GetAllConnectors().ToList();
+        return Results.Ok(connectors);
+    }
+
+    private IResult GetCurrentConnectorAsync(IConnectorStateManager stateManager)
+    {
+        var state = _factory.GetConnectorState(stateManager.CurrentConnectorType);
+        return Results.Ok(new ConnectorStatusResponse(
+            stateManager.CurrentConnectorType,
+            state,
+            true));
+    }
+
+    private async Task<IResult> SwitchConnectorAsync(
+        SwitchConnectorRequest request,
+        IConnectorStateManager stateManager,
+        CancellationToken cancellationToken)
+    {
+        try
+        {
+            await stateManager.SwitchConnectorAsync(request.ConnectorType, cancellationToken);
+            var state = _factory.GetConnectorState(request.ConnectorType);
+            return Results.Ok(new ConnectorStatusResponse(
+                stateManager.CurrentConnectorType,
+                state,
+                true));
+        }
+        catch (InvalidOperationException ex)
+        {
+            _logger.LogWarning(ex, "Failed to switch connector to {Type}", request.ConnectorType);
+            var state = _factory.GetConnectorState(request.ConnectorType);
+            return Results.BadRequest(new ConnectorStatusResponse(
+                stateManager.CurrentConnectorType,
+                state,
+                false,
+                ex.Message));
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "Error switching connector to {Type}", request.ConnectorType);
+            return Results.BadRequest(new ConnectorStatusResponse(
+                stateManager.CurrentConnectorType,
+                ConnectorState.Failed,
+                false,
+                ex.Message));
+        }
+    }
+}

--- a/src/OpenChat.PlaygroundApp/Program.cs
+++ b/src/OpenChat.PlaygroundApp/Program.cs
@@ -1,5 +1,3 @@
-using Microsoft.Extensions.AI;
-
 using OpenChat.PlaygroundApp.Abstractions;
 using OpenChat.PlaygroundApp.Components;
 using OpenChat.PlaygroundApp.Endpoints;
@@ -22,11 +20,11 @@ builder.Services.AddSingleton(settings!);
 builder.Services.AddRazorComponents()
                 .AddInteractiveServerComponents();
 
-var chatClient = await LanguageModelConnector.CreateChatClientAsync(settings);
-
-builder.Services.AddChatClient(chatClient)
-                .UseFunctionInvocation()
-                .UseLogging();
+// Register ChatClientFactory as Singleton + IHostedService for lazy-loaded IChatClient
+builder.Services.AddSingleton<ChatClientFactory>();
+builder.Services.AddSingleton<IChatClientFactory>(sp => sp.GetRequiredService<ChatClientFactory>());
+builder.Services.AddHostedService(sp => sp.GetRequiredService<ChatClientFactory>());
+builder.Services.AddScoped<IConnectorStateManager, ConnectorStateManager>();
 
 builder.Services.AddHttpContextAccessor();
 builder.Services.AddOpenApi("openapi", options =>

--- a/src/OpenChat.PlaygroundApp/Services/ChatClientFactory.cs
+++ b/src/OpenChat.PlaygroundApp/Services/ChatClientFactory.cs
@@ -1,0 +1,266 @@
+using System.Collections.Concurrent;
+
+using Microsoft.Extensions.AI;
+
+using OpenChat.PlaygroundApp.Abstractions;
+using OpenChat.PlaygroundApp.Configurations;
+using OpenChat.PlaygroundApp.Connectors;
+using OpenChat.PlaygroundApp.Contracts;
+
+namespace OpenChat.PlaygroundApp.Services;
+
+/// <summary>
+/// This represents the chat client factory entity.
+/// Manages connector states and provides lazy-loaded IChatClient instances.
+/// </summary>
+public class ChatClientFactory(
+    AppSettings settings,
+    ILoggerFactory loggerFactory,
+    ILogger<ChatClientFactory> logger) : IChatClientFactory, IHostedService
+{
+    private readonly AppSettings _settings = settings ?? throw new ArgumentNullException(nameof(settings));
+    private readonly ILoggerFactory _loggerFactory = loggerFactory ?? throw new ArgumentNullException(nameof(loggerFactory));
+    private readonly ILogger<ChatClientFactory> _logger = logger ?? throw new ArgumentNullException(nameof(logger));
+
+    // Cached clients (Lazy Loading)
+    private readonly ConcurrentDictionary<ConnectorType, IChatClient> _clients = new();
+    // Connector states
+    private readonly ConcurrentDictionary<ConnectorType, ConnectorState> _states = new();
+    // Error messages
+    private readonly ConcurrentDictionary<ConnectorType, string?> _errors = new();
+    // Initialization locks (prevent concurrent creation)
+    private readonly ConcurrentDictionary<ConnectorType, SemaphoreSlim> _initLocks = new();
+
+    /// <summary>
+    /// Non-blocking startup - validates settings in background.
+    /// </summary>
+    public Task StartAsync(CancellationToken cancellationToken)
+    {
+        _logger.LogInformation("ChatClientFactory starting - validating connector settings...");
+
+        // Fire-and-Forget: Don't block app startup
+        _ = Task.Run(() =>
+        {
+            foreach (var type in Enum.GetValues<ConnectorType>())
+            {
+                if (type == ConnectorType.Unknown) continue;
+
+                _initLocks[type] = new SemaphoreSlim(1, 1);
+                ValidateConnectorSettings(type);
+            }
+
+            var readyCount = _states.Count(s => s.Value == ConnectorState.Ready);
+            var notConfiguredCount = _states.Count(s => s.Value == ConnectorState.NotConfigured);
+            _logger.LogInformation(
+                "Connector settings validation complete. Ready: {Ready}, NotConfigured: {NotConfigured}",
+                readyCount, notConfiguredCount);
+        }, cancellationToken);
+
+        return Task.CompletedTask;  // Return immediately
+    }
+
+    /// <inheritdoc/>
+    public Task StopAsync(CancellationToken cancellationToken)
+    {
+        // Dispose all clients
+        foreach (var client in _clients.Values)
+        {
+            if (client is IDisposable disposable)
+            {
+                disposable.Dispose();
+            }
+        }
+        _clients.Clear();
+        return Task.CompletedTask;
+    }
+
+    /// <summary>
+    /// Validates connector settings without creating IChatClient.
+    /// </summary>
+    private void ValidateConnectorSettings(ConnectorType type)
+    {
+        try
+        {
+            var isConfigured = type switch
+            {
+                ConnectorType.Ollama => !string.IsNullOrWhiteSpace(_settings.Ollama?.BaseUrl),
+                ConnectorType.OpenAI => !string.IsNullOrWhiteSpace(_settings.OpenAI?.ApiKey),
+                ConnectorType.Anthropic => !string.IsNullOrWhiteSpace(_settings.Anthropic?.ApiKey),
+                ConnectorType.AzureAIFoundry => !string.IsNullOrWhiteSpace(_settings.AzureAIFoundry?.Endpoint)
+                                                 && !string.IsNullOrWhiteSpace(_settings.AzureAIFoundry?.ApiKey),
+                ConnectorType.AmazonBedrock => !string.IsNullOrWhiteSpace(_settings.AmazonBedrock?.AccessKeyId)
+                                               && !string.IsNullOrWhiteSpace(_settings.AmazonBedrock?.SecretAccessKey)
+                                               && !string.IsNullOrWhiteSpace(_settings.AmazonBedrock?.Region),
+                ConnectorType.GitHubModels => !string.IsNullOrWhiteSpace(_settings.GitHubModels?.Token),
+                ConnectorType.GoogleVertexAI => !string.IsNullOrWhiteSpace(_settings.GoogleVertexAI?.ApiKey),
+                ConnectorType.DockerModelRunner => !string.IsNullOrWhiteSpace(_settings.DockerModelRunner?.BaseUrl),
+                ConnectorType.FoundryLocal => !string.IsNullOrWhiteSpace(_settings.FoundryLocal?.ServiceUrl),
+                ConnectorType.HuggingFace => !string.IsNullOrWhiteSpace(_settings.HuggingFace?.BaseUrl),
+                ConnectorType.LG => !string.IsNullOrWhiteSpace(_settings.LG?.BaseUrl),
+                ConnectorType.Upstage => !string.IsNullOrWhiteSpace(_settings.Upstage?.ApiKey),
+                _ => false
+            };
+
+            _states[type] = isConfigured ? ConnectorState.Ready : ConnectorState.NotConfigured;
+
+            if (!isConfigured)
+            {
+                _errors[type] = "Required settings not configured";
+                _logger.LogDebug("Connector {Type}: NotConfigured", type);
+            }
+            else
+            {
+                _logger.LogDebug("Connector {Type}: Ready", type);
+            }
+        }
+        catch (Exception ex)
+        {
+            _states[type] = ConnectorState.NotConfigured;
+            _errors[type] = ex.Message;
+            _logger.LogWarning(ex, "Error validating connector {Type}", type);
+        }
+    }
+
+    /// <summary>
+    /// Lazy loads and caches IChatClient on first request.
+    /// </summary>
+    public async Task<IChatClient> GetOrCreateChatClientAsync(
+        ConnectorType type,
+        CancellationToken cancellationToken = default)
+    {
+        // Already cached
+        if (_clients.TryGetValue(type, out var cachedClient))
+        {
+            return cachedClient;
+        }
+
+        // Not configured
+        if (_states.TryGetValue(type, out var state) && state == ConnectorState.NotConfigured)
+        {
+            throw new InvalidOperationException($"Connector {type} is not configured");
+        }
+
+        // Prevent concurrent initialization
+        var initLock = _initLocks.GetOrAdd(type, _ => new SemaphoreSlim(1, 1));
+        await initLock.WaitAsync(cancellationToken);
+
+        try
+        {
+            // Double-check
+            if (_clients.TryGetValue(type, out cachedClient))
+            {
+                return cachedClient;
+            }
+
+            _logger.LogInformation("Creating chat client for connector {Type}...", type);
+
+            // Clone settings with overridden ConnectorType
+            var clonedSettings = CloneSettingsWithType(type);
+
+            // Create actual IChatClient
+            var baseClient = await LanguageModelConnector.CreateChatClientAsync(clonedSettings);
+
+            // Apply middleware
+            var clientWithMiddleware = baseClient.AsBuilder()
+                .UseFunctionInvocation()
+                .UseLogging(_loggerFactory)
+                .Build();
+
+            _clients[type] = clientWithMiddleware;
+            _states[type] = ConnectorState.Active;
+            _errors.TryRemove(type, out _);
+
+            _logger.LogInformation("Chat client for connector {Type} created successfully", type);
+
+            return clientWithMiddleware;
+        }
+        catch (Exception ex)
+        {
+            _states[type] = ConnectorState.Failed;
+            _errors[type] = ex.Message;
+            _logger.LogError(ex, "Failed to create chat client for connector {Type}", type);
+            throw;
+        }
+        finally
+        {
+            initLock.Release();
+        }
+    }
+
+    /// <inheritdoc/>
+    public IChatClient? GetCachedChatClient(ConnectorType type)
+        => _clients.TryGetValue(type, out var client) ? client : null;
+
+    /// <inheritdoc/>
+    public IEnumerable<ConnectorInfo> GetAllConnectors()
+    {
+        return Enum.GetValues<ConnectorType>()
+            .Where(t => t != ConnectorType.Unknown)
+            .Select(t => new ConnectorInfo(
+                t,
+                t.ToString(),
+                GetConnectorState(t),
+                GetConnectorError(t),
+                _clients.ContainsKey(t)));
+    }
+
+    /// <inheritdoc/>
+    public IEnumerable<ConnectorInfo> GetAvailableConnectors()
+        => GetAllConnectors().Where(c => c.State is ConnectorState.Ready or ConnectorState.Active);
+
+    /// <inheritdoc/>
+    public ConnectorState GetConnectorState(ConnectorType type)
+        => _states.TryGetValue(type, out var state) ? state : ConnectorState.NotConfigured;
+
+    /// <inheritdoc/>
+    public string? GetConnectorError(ConnectorType type)
+        => _errors.TryGetValue(type, out var error) ? error : null;
+
+    /// <summary>
+    /// Creates a copy of settings with overridden ConnectorType.
+    /// AppSettings already contains all connector settings from config.Bind().
+    /// </summary>
+    private AppSettings CloneSettingsWithType(ConnectorType type)
+    {
+        // Note: config.Bind() already loaded all settings
+        // Simply override ConnectorType
+        return new AppSettings
+        {
+            ConnectorType = type,
+            Model = GetModelForType(type),
+            // All connector settings reference from original
+            Ollama = _settings.Ollama,
+            OpenAI = _settings.OpenAI,
+            Anthropic = _settings.Anthropic,
+            AzureAIFoundry = _settings.AzureAIFoundry,
+            AmazonBedrock = _settings.AmazonBedrock,
+            GitHubModels = _settings.GitHubModels,
+            GoogleVertexAI = _settings.GoogleVertexAI,
+            DockerModelRunner = _settings.DockerModelRunner,
+            FoundryLocal = _settings.FoundryLocal,
+            HuggingFace = _settings.HuggingFace,
+            LG = _settings.LG,
+            Upstage = _settings.Upstage
+        };
+    }
+
+    private string? GetModelForType(ConnectorType type)
+    {
+        return type switch
+        {
+            ConnectorType.Ollama => _settings.Ollama?.Model,
+            ConnectorType.OpenAI => _settings.OpenAI?.Model,
+            ConnectorType.Anthropic => _settings.Anthropic?.Model,
+            ConnectorType.AzureAIFoundry => _settings.AzureAIFoundry?.DeploymentName,
+            ConnectorType.AmazonBedrock => _settings.AmazonBedrock?.ModelId,
+            ConnectorType.GitHubModels => _settings.GitHubModels?.Model,
+            ConnectorType.GoogleVertexAI => _settings.GoogleVertexAI?.Model,
+            ConnectorType.DockerModelRunner => _settings.DockerModelRunner?.Model,
+            ConnectorType.FoundryLocal => _settings.FoundryLocal?.Alias,
+            ConnectorType.HuggingFace => _settings.HuggingFace?.Model,
+            ConnectorType.LG => _settings.LG?.Model,
+            ConnectorType.Upstage => _settings.Upstage?.Model,
+            _ => null
+        };
+    }
+}

--- a/src/OpenChat.PlaygroundApp/Services/ChatService.cs
+++ b/src/OpenChat.PlaygroundApp/Services/ChatService.cs
@@ -1,5 +1,7 @@
 using Microsoft.Extensions.AI;
 
+using OpenChat.PlaygroundApp.Abstractions;
+
 namespace OpenChat.PlaygroundApp.Services;
 
 /// <summary>
@@ -21,13 +23,13 @@ public interface IChatService
 }
 
 /// <summary>
-/// This represents the service entity for chat operations.
+/// This represents the chat service entity.
 /// </summary>
-/// <param name="chatClient">The <see cref="IChatClient"/>.</param>
-/// <param name="logger">The <see cref="ILogger{ChatService}"/>.</param>
-public class ChatService(IChatClient chatClient, ILogger<ChatService> logger) : IChatService
+public class ChatService(
+    IConnectorStateManager stateManager,
+    ILogger<ChatService> logger) : IChatService
 {
-    private readonly IChatClient _chatClient = chatClient ?? throw new ArgumentNullException(nameof(chatClient));
+    private readonly IConnectorStateManager _stateManager = stateManager ?? throw new ArgumentNullException(nameof(stateManager));
     private readonly ILogger<ChatService> _logger = logger ?? throw new ArgumentNullException(nameof(logger));
 
     /// <inheritdoc/>
@@ -37,6 +39,7 @@ public class ChatService(IChatClient chatClient, ILogger<ChatService> logger) : 
         CancellationToken cancellationToken = default)
     {
         var chats = messages.ToList();
+
         if (chats.Count < 2)
         {
             throw new ArgumentException("At least two messages are required", nameof(messages));
@@ -52,8 +55,13 @@ public class ChatService(IChatClient chatClient, ILogger<ChatService> logger) : 
             throw new ArgumentException("The second message must be a user message", nameof(messages));
         }
 
-        this._logger.LogInformation("Requesting chat response with {MessageCount} messages", chats.Count);
+        var currentClient = _stateManager.CurrentChatClient
+            ?? throw new InvalidOperationException("No chat client is currently initialized. Call EnsureInitializedAsync first.");
 
-        return this._chatClient.GetStreamingResponseAsync(chats, options, cancellationToken);
+        _logger.LogInformation(
+            "Requesting chat response with {MessageCount} messages using connector {ConnectorType}",
+            chats.Count, _stateManager.CurrentConnectorType);
+
+        return currentClient.GetStreamingResponseAsync(chats, options, cancellationToken);
     }
 }

--- a/src/OpenChat.PlaygroundApp/Services/ChatService.cs
+++ b/src/OpenChat.PlaygroundApp/Services/ChatService.cs
@@ -38,6 +38,12 @@ public class ChatService(
         ChatOptions? options = null,
         CancellationToken cancellationToken = default)
     {
+        // Block chat requests during connector switching
+        if (_stateManager.IsSwitching)
+        {
+            throw new InvalidOperationException("Cannot send chat requests while connector is being switched. Please wait for the switch to complete.");
+        }
+
         var chats = messages.ToList();
 
         if (chats.Count < 2)

--- a/src/OpenChat.PlaygroundApp/Services/ConnectorStateManager.cs
+++ b/src/OpenChat.PlaygroundApp/Services/ConnectorStateManager.cs
@@ -26,7 +26,13 @@ public class ConnectorStateManager(
     public IChatClient? CurrentChatClient { get; private set; }
 
     /// <inheritdoc/>
+    public bool IsSwitching { get; private set; }
+
+    /// <inheritdoc/>
     public event EventHandler<ConnectorType>? OnConnectorChanged;
+
+    /// <inheritdoc/>
+    public event EventHandler<bool>? OnSwitchingStateChanged;
 
     /// <inheritdoc/>
     public async Task EnsureInitializedAsync(CancellationToken cancellationToken = default)
@@ -78,6 +84,9 @@ public class ConnectorStateManager(
         _logger.LogInformation("Switching connector from {OldType} to {NewType}",
             CurrentConnectorType, type);
 
+        // Set switching state to block chat requests
+        SetSwitchingState(true);
+
         try
         {
             // Lazy Loading: Create IChatClient on first request
@@ -94,6 +103,21 @@ public class ConnectorStateManager(
         {
             _logger.LogError(ex, "Failed to switch to connector {Type}", type);
             throw;
+        }
+        finally
+        {
+            // Always reset switching state
+            SetSwitchingState(false);
+        }
+    }
+
+    private void SetSwitchingState(bool isSwitching)
+    {
+        if (IsSwitching != isSwitching)
+        {
+            IsSwitching = isSwitching;
+            OnSwitchingStateChanged?.Invoke(this, isSwitching);
+            _logger.LogDebug("Switching state changed to {IsSwitching}", isSwitching);
         }
     }
 }

--- a/src/OpenChat.PlaygroundApp/Services/ConnectorStateManager.cs
+++ b/src/OpenChat.PlaygroundApp/Services/ConnectorStateManager.cs
@@ -1,0 +1,99 @@
+using Microsoft.Extensions.AI;
+
+using OpenChat.PlaygroundApp.Abstractions;
+using OpenChat.PlaygroundApp.Configurations;
+using OpenChat.PlaygroundApp.Connectors;
+
+namespace OpenChat.PlaygroundApp.Services;
+
+/// <summary>
+/// This represents the connector state manager entity.
+/// Manages connector state per Blazor circuit (scoped).
+/// </summary>
+public class ConnectorStateManager(
+    IChatClientFactory factory,
+    AppSettings settings,
+    ILogger<ConnectorStateManager> logger) : IConnectorStateManager
+{
+    private readonly IChatClientFactory _factory = factory ?? throw new ArgumentNullException(nameof(factory));
+    private readonly AppSettings _settings = settings ?? throw new ArgumentNullException(nameof(settings));
+    private readonly ILogger<ConnectorStateManager> _logger = logger ?? throw new ArgumentNullException(nameof(logger));
+
+    /// <inheritdoc/>
+    public ConnectorType CurrentConnectorType { get; private set; } = ConnectorType.Unknown;
+
+    /// <inheritdoc/>
+    public IChatClient? CurrentChatClient { get; private set; }
+
+    /// <inheritdoc/>
+    public event EventHandler<ConnectorType>? OnConnectorChanged;
+
+    /// <inheritdoc/>
+    public async Task EnsureInitializedAsync(CancellationToken cancellationToken = default)
+    {
+        if (CurrentChatClient != null)
+        {
+            return;
+        }
+
+        var defaultType = _settings.ConnectorType;
+        if (defaultType == ConnectorType.Unknown)
+        {
+            // Select first available connector
+            var available = _factory.GetAvailableConnectors().FirstOrDefault();
+            if (available != null)
+            {
+                defaultType = available.Type;
+            }
+            else
+            {
+                _logger.LogWarning("No connectors available for initialization");
+                return;
+            }
+        }
+
+        await SwitchConnectorAsync(defaultType, cancellationToken);
+    }
+
+    /// <inheritdoc/>
+    public async Task SwitchConnectorAsync(ConnectorType type, CancellationToken cancellationToken = default)
+    {
+        if (type == CurrentConnectorType && CurrentChatClient != null)
+        {
+            _logger.LogDebug("Connector already set to {Type}, skipping switch", type);
+            return;
+        }
+
+        if (!Enum.IsDefined(typeof(ConnectorType), type) || type == ConnectorType.Unknown)
+        {
+            throw new ArgumentException($"Invalid connector type: {type}", nameof(type));
+        }
+
+        var state = _factory.GetConnectorState(type);
+        if (state == ConnectorState.NotConfigured)
+        {
+            throw new InvalidOperationException($"Connector {type} is not configured");
+        }
+
+        _logger.LogInformation("Switching connector from {OldType} to {NewType}",
+            CurrentConnectorType, type);
+
+        try
+        {
+            // Lazy Loading: Create IChatClient on first request
+            var client = await _factory.GetOrCreateChatClientAsync(type, cancellationToken);
+
+            CurrentConnectorType = type;
+            CurrentChatClient = client;
+
+            OnConnectorChanged?.Invoke(this, type);
+
+            _logger.LogInformation("Successfully switched to connector {Type}", type);
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "Failed to switch to connector {Type}", type);
+            throw;
+        }
+    }
+}

--- a/src/OpenChat.PlaygroundApp/appsettings.json
+++ b/src/OpenChat.PlaygroundApp/appsettings.json
@@ -41,8 +41,8 @@
   },
 
   "FoundryLocal": {
-    "ServiceUrl": "http://localhost:55588",
-    "Alias": "phi-4-mini"
+    "ServiceUrl": "http://localhost:58032",
+    "Alias": "Phi-4-mini-instruct-generic-gpu:5"
   },
 
   "HuggingFace": {

--- a/src/OpenChat.PlaygroundApp/appsettings.json
+++ b/src/OpenChat.PlaygroundApp/appsettings.json
@@ -42,7 +42,7 @@
 
   "FoundryLocal": {
     "ServiceUrl": "http://localhost:58032",
-    "Alias": "Phi-4-mini-instruct-generic-gpu:5"
+    "Alias": "phi-4-mini"
   },
 
   "HuggingFace": {

--- a/test/OpenChat.PlaygroundApp.Tests/Components/Pages/Chat/ConnectorMultiTabUITests.cs
+++ b/test/OpenChat.PlaygroundApp.Tests/Components/Pages/Chat/ConnectorMultiTabUITests.cs
@@ -50,16 +50,12 @@ public class ConnectorMultiTabUITests : PageTest
 
         // Act - Select different connectors in each tab
         await selector1.SelectOptionAsync(connectors[0]);
-        await page1.WaitForFunctionAsync(
-            "() => !document.querySelector('textarea[aria-label=\"User Message Textarea\"]').disabled",
-            options: new() { Timeout = TimeoutMs }
-        );
+        var textArea1 = page1.GetByRole(AriaRole.Textbox, new() { Name = "User Message Textarea" });
+        await Expect(textArea1).Not.ToBeDisabledAsync(new() { Timeout = TimeoutMs });
 
         await selector2.SelectOptionAsync(connectors[1]);
-        await page2.WaitForFunctionAsync(
-            "() => !document.querySelector('textarea[aria-label=\"User Message Textarea\"]').disabled",
-            options: new() { Timeout = TimeoutMs }
-        );
+        var textArea2 = page2.GetByRole(AriaRole.Textbox, new() { Name = "User Message Textarea" });
+        await Expect(textArea2).Not.ToBeDisabledAsync(new() { Timeout = TimeoutMs });
 
         // Assert - Each tab should have its own selected connector
         var value1 = await selector1.InputValueAsync();
@@ -182,10 +178,7 @@ public class ConnectorMultiTabUITests : PageTest
         // Act - Switch connector in first tab only
         await selector1.SelectOptionAsync(otherConnector);
 
-        await page1.WaitForFunctionAsync(
-            "() => !document.querySelector('textarea[aria-label=\"User Message Textarea\"]').disabled",
-            options: new() { Timeout = TimeoutMs }
-        );
+        await Expect(textArea1).Not.ToBeDisabledAsync(new() { Timeout = TimeoutMs });
 
         // Assert - Second tab should still have original connector
         var tab2CurrentConnector = await selector2.InputValueAsync();

--- a/test/OpenChat.PlaygroundApp.Tests/Components/Pages/Chat/ConnectorMultiTabUITests.cs
+++ b/test/OpenChat.PlaygroundApp.Tests/Components/Pages/Chat/ConnectorMultiTabUITests.cs
@@ -1,0 +1,207 @@
+using Microsoft.Playwright;
+using Microsoft.Playwright.Xunit;
+
+namespace OpenChat.PlaygroundApp.Tests.Components.Pages.Chat;
+
+public class ConnectorMultiTabUITests : PageTest
+{
+    private const int TimeoutMs = 60000;
+
+    [Trait("Category", "IntegrationTest")]
+    [Trait("Category", "UI")]
+    [Trait("Category", "LLMRequired")]
+    [Fact]
+    public async Task Given_Two_Tabs_When_Different_Connectors_Selected_Then_Each_Tab_Should_Have_Own_State()
+    {
+        // Arrange - First tab
+        var page1 = Page;
+        await page1.GotoAsync(TestConstants.LocalhostUrl);
+        await page1.WaitForLoadStateAsync(LoadState.NetworkIdle);
+
+        var selector1 = page1.Locator("#connector-select");
+        var initialValue = await selector1.InputValueAsync();
+
+        // Find available connectors
+        var options1 = page1.Locator("#connector-select option:not(:disabled)");
+        var count = await options1.CountAsync();
+
+        if (count < 2)
+        {
+            // Skip if only one connector is available
+            return;
+        }
+
+        // Get two different connector values
+        var connectors = new List<string>();
+        for (int i = 0; i < count && connectors.Count < 2; i++)
+        {
+            var value = await options1.Nth(i).GetAttributeAsync("value");
+            if (value != null) connectors.Add(value);
+        }
+
+        if (connectors.Count < 2) return;
+
+        // Arrange - Second tab
+        var page2 = await Context.NewPageAsync();
+        await page2.GotoAsync(TestConstants.LocalhostUrl);
+        await page2.WaitForLoadStateAsync(LoadState.NetworkIdle);
+
+        var selector2 = page2.Locator("#connector-select");
+
+        // Act - Select different connectors in each tab
+        await selector1.SelectOptionAsync(connectors[0]);
+        await page1.WaitForFunctionAsync(
+            "() => !document.querySelector('textarea[aria-label=\"User Message Textarea\"]').disabled",
+            options: new() { Timeout = TimeoutMs }
+        );
+
+        await selector2.SelectOptionAsync(connectors[1]);
+        await page2.WaitForFunctionAsync(
+            "() => !document.querySelector('textarea[aria-label=\"User Message Textarea\"]').disabled",
+            options: new() { Timeout = TimeoutMs }
+        );
+
+        // Assert - Each tab should have its own selected connector
+        var value1 = await selector1.InputValueAsync();
+        var value2 = await selector2.InputValueAsync();
+
+        value1.ShouldBe(connectors[0]);
+        value2.ShouldBe(connectors[1]);
+        value1.ShouldNotBe(value2);
+
+        // Cleanup
+        await page2.CloseAsync();
+    }
+
+    [Trait("Category", "IntegrationTest")]
+    [Trait("Category", "UI")]
+    [Trait("Category", "LLMRequired")]
+    [Theory]
+    [InlineData("What is 1+1?", "What is 2+2?")]
+    public async Task Given_Two_Tabs_When_Chat_Sent_Then_Each_Tab_Should_Work_Independently(
+        string message1, string message2)
+    {
+        // Arrange - First tab
+        var page1 = Page;
+        await page1.GotoAsync(TestConstants.LocalhostUrl);
+        await page1.WaitForLoadStateAsync(LoadState.NetworkIdle);
+
+        // Arrange - Second tab
+        var page2 = await Context.NewPageAsync();
+        await page2.GotoAsync(TestConstants.LocalhostUrl);
+        await page2.WaitForLoadStateAsync(LoadState.NetworkIdle);
+
+        var textArea1 = page1.GetByRole(AriaRole.Textbox, new() { Name = "User Message Textarea" });
+        var sendButton1 = page1.GetByRole(AriaRole.Button, new() { Name = "User Message Send Button" });
+
+        var textArea2 = page2.GetByRole(AriaRole.Textbox, new() { Name = "User Message Textarea" });
+        var sendButton2 = page2.GetByRole(AriaRole.Button, new() { Name = "User Message Send Button" });
+
+        // Act - Send different messages in each tab
+        await textArea1.FillAsync(message1);
+        await sendButton1.ClickAsync();
+
+        await textArea2.FillAsync(message2);
+        await sendButton2.ClickAsync();
+
+        // Assert - Both tabs should receive responses
+        await page1.WaitForFunctionAsync(
+            "() => document.querySelectorAll('.assistant-message-header').length >= 1",
+            options: new() { Timeout = TimeoutMs }
+        );
+
+        await page2.WaitForFunctionAsync(
+            "() => document.querySelectorAll('.assistant-message-header').length >= 1",
+            options: new() { Timeout = TimeoutMs }
+        );
+
+        var count1 = await page1.Locator(".assistant-message-header").CountAsync();
+        var count2 = await page2.Locator(".assistant-message-header").CountAsync();
+
+        count1.ShouldBeGreaterThanOrEqualTo(1);
+        count2.ShouldBeGreaterThanOrEqualTo(1);
+
+        // Verify user messages are different
+        var userMessage1 = await page1.Locator(".user-message").First.InnerTextAsync();
+        var userMessage2 = await page2.Locator(".user-message").First.InnerTextAsync();
+
+        userMessage1.ShouldContain(message1);
+        userMessage2.ShouldContain(message2);
+
+        // Cleanup
+        await page2.CloseAsync();
+    }
+
+    [Trait("Category", "IntegrationTest")]
+    [Trait("Category", "UI")]
+    [Trait("Category", "LLMRequired")]
+    [Fact]
+    public async Task Given_Two_Tabs_When_One_Tab_Switches_Connector_Then_Other_Tab_Should_Not_Be_Affected()
+    {
+        // Arrange - First tab
+        var page1 = Page;
+        await page1.GotoAsync(TestConstants.LocalhostUrl);
+        await page1.WaitForLoadStateAsync(LoadState.NetworkIdle);
+
+        var selector1 = page1.Locator("#connector-select");
+        var textArea1 = page1.GetByRole(AriaRole.Textbox, new() { Name = "User Message Textarea" });
+
+        // Find available connectors
+        var options1 = page1.Locator("#connector-select option:not(:disabled)");
+        var count = await options1.CountAsync();
+
+        if (count < 2) return;
+
+        var initialConnector = await selector1.InputValueAsync();
+
+        string? otherConnector = null;
+        for (int i = 0; i < count; i++)
+        {
+            var value = await options1.Nth(i).GetAttributeAsync("value");
+            if (value != initialConnector)
+            {
+                otherConnector = value;
+                break;
+            }
+        }
+
+        if (otherConnector == null) return;
+
+        // Arrange - Second tab
+        var page2 = await Context.NewPageAsync();
+        await page2.GotoAsync(TestConstants.LocalhostUrl);
+        await page2.WaitForLoadStateAsync(LoadState.NetworkIdle);
+
+        var selector2 = page2.Locator("#connector-select");
+        var textArea2 = page2.GetByRole(AriaRole.Textbox, new() { Name = "User Message Textarea" });
+
+        // Verify both tabs start with same connector
+        var tab2InitialConnector = await selector2.InputValueAsync();
+        tab2InitialConnector.ShouldBe(initialConnector);
+
+        // Act - Switch connector in first tab only
+        await selector1.SelectOptionAsync(otherConnector);
+
+        await page1.WaitForFunctionAsync(
+            "() => !document.querySelector('textarea[aria-label=\"User Message Textarea\"]').disabled",
+            options: new() { Timeout = TimeoutMs }
+        );
+
+        // Assert - Second tab should still have original connector
+        var tab2CurrentConnector = await selector2.InputValueAsync();
+        tab2CurrentConnector.ShouldBe(initialConnector);
+
+        // Verify second tab's input is still enabled
+        var isDisabled = await textArea2.GetAttributeAsync("disabled");
+        isDisabled.ShouldBeNull();
+
+        // Cleanup
+        await page2.CloseAsync();
+    }
+
+    public override async Task DisposeAsync()
+    {
+        await Page.CloseAsync();
+        await base.DisposeAsync();
+    }
+}

--- a/test/OpenChat.PlaygroundApp.Tests/Components/Pages/Chat/ConnectorSelectorUITests.cs
+++ b/test/OpenChat.PlaygroundApp.Tests/Components/Pages/Chat/ConnectorSelectorUITests.cs
@@ -1,0 +1,115 @@
+using Microsoft.Playwright;
+using Microsoft.Playwright.Xunit;
+
+namespace OpenChat.PlaygroundApp.Tests.Components.Pages.Chat;
+
+public class ConnectorSelectorUITests : PageTest
+{
+    private const int TimeoutMs = 60000;
+
+    public override async Task InitializeAsync()
+    {
+        await base.InitializeAsync();
+        await Page.GotoAsync(TestConstants.LocalhostUrl);
+        await Page.WaitForLoadStateAsync(LoadState.NetworkIdle);
+    }
+
+    [Trait("Category", "IntegrationTest")]
+    [Trait("Category", "UI")]
+    [Fact]
+    public async Task Given_Root_Page_When_Loaded_Then_ConnectorSelector_Should_Be_Visible()
+    {
+        // Arrange
+        var selector = Page.Locator("#connector-select");
+
+        // Assert
+        var isVisible = await selector.IsVisibleAsync();
+        isVisible.ShouldBeTrue();
+    }
+
+    [Trait("Category", "IntegrationTest")]
+    [Trait("Category", "UI")]
+    [Fact]
+    public async Task Given_Root_Page_When_Loaded_Then_ConnectorSelector_Should_Show_Current_Connector()
+    {
+        // Arrange
+        var selector = Page.Locator("#connector-select");
+
+        // Act
+        var selectedValue = await selector.InputValueAsync();
+
+        // Assert
+        selectedValue.ShouldNotBeNullOrEmpty();
+    }
+
+    [Trait("Category", "IntegrationTest")]
+    [Trait("Category", "UI")]
+    [Fact]
+    public async Task Given_ConnectorSelector_When_Clicked_Then_All_Connectors_Should_Be_Listed()
+    {
+        // Arrange
+        var options = Page.Locator("#connector-select option");
+
+        // Act
+        var count = await options.CountAsync();
+
+        // Assert
+        count.ShouldBeGreaterThan(1);
+    }
+
+    [Trait("Category", "IntegrationTest")]
+    [Trait("Category", "UI")]
+    [Fact]
+    public async Task Given_NotConfigured_Connector_When_Dropdown_Opened_Then_Option_Should_Be_Disabled()
+    {
+        // Arrange - Naver connector should always be NotConfigured in test environment
+        var naverOption = Page.Locator("#connector-select option[value='Naver']");
+
+        // Act
+        var isDisabled = await naverOption.GetAttributeAsync("disabled");
+        var text = await naverOption.InnerTextAsync();
+
+        // Assert - Naver should be disabled and show "(Not Configured)"
+        isDisabled.ShouldNotBeNull();
+        text.ShouldContain("Naver");
+        text.ShouldContain("(Not Configured)");
+    }
+
+    [Trait("Category", "IntegrationTest")]
+    [Trait("Category", "UI")]
+    [Fact]
+    public async Task Given_Active_Connector_When_Dropdown_Opened_Then_Option_Should_Show_Bullet()
+    {
+        // Arrange
+        var selector = Page.Locator("#connector-select");
+        var selectedValue = await selector.InputValueAsync();
+
+        // Act
+        var selectedOption = Page.Locator($"#connector-select option[value='{selectedValue}']");
+        var text = await selectedOption.InnerTextAsync();
+
+        // Assert - Active connector should have ● symbol
+        text.ShouldContain("●");
+    }
+
+    [Trait("Category", "IntegrationTest")]
+    [Trait("Category", "UI")]
+    [Fact]
+    public async Task Given_Root_Page_When_Loaded_Then_Connector_Label_Should_Be_Visible()
+    {
+        // Arrange
+        var label = Page.Locator(".connector-selector label");
+
+        // Act
+        var text = await label.InnerTextAsync();
+
+        // Assert
+        text.ShouldBe("Connector:");
+    }
+
+    public override async Task DisposeAsync()
+    {
+        await Page.CloseAsync();
+        await base.DisposeAsync();
+    }
+}

--- a/test/OpenChat.PlaygroundApp.Tests/Components/Pages/Chat/ConnectorSwitchingUITests.cs
+++ b/test/OpenChat.PlaygroundApp.Tests/Components/Pages/Chat/ConnectorSwitchingUITests.cs
@@ -53,14 +53,8 @@ public class ConnectorSwitchingUITests : PageTest
         // Act - Switch connector
         await selector.SelectOptionAsync(targetValue);
 
-        // Assert - After switch completes, placeholder should return to normal
-        await Page.WaitForFunctionAsync(
-            "() => document.querySelector('textarea[aria-label=\"User Message Textarea\"]').placeholder === 'Type your message...'",
-            options: new() { Timeout = TimeoutMs }
-        );
-
-        var placeholder = await textArea.GetAttributeAsync("placeholder");
-        placeholder.ShouldBe("Type your message...");
+        // Assert - After switch completes, textarea should be enabled
+        await Expect(textArea).Not.ToBeDisabledAsync(new() { Timeout = TimeoutMs });
     }
 
     [Trait("Category", "IntegrationTest")]
@@ -96,15 +90,8 @@ public class ConnectorSwitchingUITests : PageTest
         // Act
         await selector.SelectOptionAsync(targetValue);
 
-        // Wait for switch to complete
-        await Page.WaitForFunctionAsync(
-            "() => !document.querySelector('textarea[aria-label=\"User Message Textarea\"]').disabled",
-            options: new() { Timeout = TimeoutMs }
-        );
-
-        // Assert
-        var isDisabled = await textArea.GetAttributeAsync("disabled");
-        isDisabled.ShouldBeNull();
+        // Assert - After switch completes, textarea should be enabled
+        await Expect(textArea).Not.ToBeDisabledAsync(new() { Timeout = TimeoutMs });
     }
 
     [Trait("Category", "IntegrationTest")]
@@ -143,10 +130,7 @@ public class ConnectorSwitchingUITests : PageTest
         await selector.SelectOptionAsync(targetValue);
 
         // Wait for switch to complete
-        await Page.WaitForFunctionAsync(
-            "() => !document.querySelector('textarea[aria-label=\"User Message Textarea\"]').disabled",
-            options: new() { Timeout = TimeoutMs }
-        );
+        await Expect(textArea).Not.ToBeDisabledAsync(new() { Timeout = TimeoutMs });
 
         // Send a message
         var messageCountBefore = await Page.Locator(".assistant-message-header").CountAsync();
@@ -210,11 +194,9 @@ public class ConnectorSwitchingUITests : PageTest
             // Switching was too fast to catch spinner, which is acceptable
         }
 
-        // After switch completes, spinner should be hidden
-        await Page.WaitForFunctionAsync(
-            "() => !document.querySelector('.loading-spinner') || document.querySelector('.loading-spinner').style.display === 'none' || !document.querySelector('.loading-spinner').offsetParent",
-            options: new() { Timeout = TimeoutMs }
-        );
+        // After switch completes, textarea should be enabled
+        var textArea = Page.GetByRole(AriaRole.Textbox, new() { Name = "User Message Textarea" });
+        await Expect(textArea).Not.ToBeDisabledAsync(new() { Timeout = TimeoutMs });
     }
 
     [Trait("Category", "IntegrationTest")]
@@ -250,10 +232,8 @@ public class ConnectorSwitchingUITests : PageTest
         await selector.SelectOptionAsync(targetValue);
 
         // Wait for switch to complete
-        await Page.WaitForFunctionAsync(
-            "() => !document.querySelector('#connector-select').disabled",
-            options: new() { Timeout = TimeoutMs }
-        );
+        var textArea = Page.GetByRole(AriaRole.Textbox, new() { Name = "User Message Textarea" });
+        await Expect(textArea).Not.ToBeDisabledAsync(new() { Timeout = TimeoutMs });
 
         // Assert
         var newValue = await selector.InputValueAsync();

--- a/test/OpenChat.PlaygroundApp.Tests/Components/Pages/Chat/ConnectorSwitchingUITests.cs
+++ b/test/OpenChat.PlaygroundApp.Tests/Components/Pages/Chat/ConnectorSwitchingUITests.cs
@@ -1,0 +1,268 @@
+using Microsoft.Playwright;
+using Microsoft.Playwright.Xunit;
+
+namespace OpenChat.PlaygroundApp.Tests.Components.Pages.Chat;
+
+public class ConnectorSwitchingUITests : PageTest
+{
+    private const int TimeoutMs = 60000;
+
+    public override async Task InitializeAsync()
+    {
+        await base.InitializeAsync();
+        await Page.GotoAsync(TestConstants.LocalhostUrl);
+        await Page.WaitForLoadStateAsync(LoadState.NetworkIdle);
+    }
+
+    [Trait("Category", "IntegrationTest")]
+    [Trait("Category", "UI")]
+    [Trait("Category", "LLMRequired")]
+    [Fact]
+    public async Task Given_Connector_When_Switching_Then_ChatInput_Placeholder_Should_Change()
+    {
+        // Arrange
+        var selector = Page.Locator("#connector-select");
+        var textArea = Page.GetByRole(AriaRole.Textbox, new() { Name = "User Message Textarea" });
+
+        // Get current connector
+        var currentValue = await selector.InputValueAsync();
+
+        // Find a different ready connector (not disabled)
+        var options = Page.Locator("#connector-select option:not(:disabled)");
+        var count = await options.CountAsync();
+
+        if (count < 2)
+        {
+            // Skip if only one connector is available
+            return;
+        }
+
+        string? targetValue = null;
+        for (int i = 0; i < count; i++)
+        {
+            var value = await options.Nth(i).GetAttributeAsync("value");
+            if (value != currentValue)
+            {
+                targetValue = value;
+                break;
+            }
+        }
+
+        if (targetValue == null) return;
+
+        // Act - Switch connector
+        await selector.SelectOptionAsync(targetValue);
+
+        // Assert - After switch completes, placeholder should return to normal
+        await Page.WaitForFunctionAsync(
+            "() => document.querySelector('textarea[aria-label=\"User Message Textarea\"]').placeholder === 'Type your message...'",
+            options: new() { Timeout = TimeoutMs }
+        );
+
+        var placeholder = await textArea.GetAttributeAsync("placeholder");
+        placeholder.ShouldBe("Type your message...");
+    }
+
+    [Trait("Category", "IntegrationTest")]
+    [Trait("Category", "UI")]
+    [Trait("Category", "LLMRequired")]
+    [Fact]
+    public async Task Given_Connector_When_Switch_Completes_Then_ChatInput_Should_Be_Enabled()
+    {
+        // Arrange
+        var selector = Page.Locator("#connector-select");
+        var textArea = Page.GetByRole(AriaRole.Textbox, new() { Name = "User Message Textarea" });
+
+        var currentValue = await selector.InputValueAsync();
+
+        var options = Page.Locator("#connector-select option:not(:disabled)");
+        var count = await options.CountAsync();
+
+        if (count < 2) return;
+
+        string? targetValue = null;
+        for (int i = 0; i < count; i++)
+        {
+            var value = await options.Nth(i).GetAttributeAsync("value");
+            if (value != currentValue)
+            {
+                targetValue = value;
+                break;
+            }
+        }
+
+        if (targetValue == null) return;
+
+        // Act
+        await selector.SelectOptionAsync(targetValue);
+
+        // Wait for switch to complete
+        await Page.WaitForFunctionAsync(
+            "() => !document.querySelector('textarea[aria-label=\"User Message Textarea\"]').disabled",
+            options: new() { Timeout = TimeoutMs }
+        );
+
+        // Assert
+        var isDisabled = await textArea.GetAttributeAsync("disabled");
+        isDisabled.ShouldBeNull();
+    }
+
+    [Trait("Category", "IntegrationTest")]
+    [Trait("Category", "UI")]
+    [Trait("Category", "LLMRequired")]
+    [Theory]
+    [InlineData("Why is the sky blue?")]
+    public async Task Given_Connector_When_Switched_Then_Chat_Should_Work(string userMessage)
+    {
+        // Arrange
+        var selector = Page.Locator("#connector-select");
+        var textArea = Page.GetByRole(AriaRole.Textbox, new() { Name = "User Message Textarea" });
+        var sendButton = Page.GetByRole(AriaRole.Button, new() { Name = "User Message Send Button" });
+
+        var currentValue = await selector.InputValueAsync();
+
+        var options = Page.Locator("#connector-select option:not(:disabled)");
+        var count = await options.CountAsync();
+
+        if (count < 2) return;
+
+        string? targetValue = null;
+        for (int i = 0; i < count; i++)
+        {
+            var value = await options.Nth(i).GetAttributeAsync("value");
+            if (value != currentValue)
+            {
+                targetValue = value;
+                break;
+            }
+        }
+
+        if (targetValue == null) return;
+
+        // Act - Switch connector
+        await selector.SelectOptionAsync(targetValue);
+
+        // Wait for switch to complete
+        await Page.WaitForFunctionAsync(
+            "() => !document.querySelector('textarea[aria-label=\"User Message Textarea\"]').disabled",
+            options: new() { Timeout = TimeoutMs }
+        );
+
+        // Send a message
+        var messageCountBefore = await Page.Locator(".assistant-message-header").CountAsync();
+        await textArea.FillAsync(userMessage);
+        await sendButton.ClickAsync();
+
+        // Assert - Message should be sent and response received
+        await Page.WaitForFunctionAsync(
+            "args => document.querySelectorAll(args.selector).length >= args.expected",
+            new { selector = ".assistant-message-header", expected = messageCountBefore + 1 },
+            options: new() { Timeout = TimeoutMs }
+        );
+
+        var messageCountAfter = await Page.Locator(".assistant-message-header").CountAsync();
+        messageCountAfter.ShouldBe(messageCountBefore + 1);
+    }
+
+    [Trait("Category", "IntegrationTest")]
+    [Trait("Category", "UI")]
+    [Trait("Category", "LLMRequired")]
+    [Fact]
+    public async Task Given_Connector_When_Switching_Then_Loading_Spinner_Should_Appear()
+    {
+        // Arrange
+        var selector = Page.Locator("#connector-select");
+        var loadingSpinner = Page.Locator(".loading-spinner");
+
+        var currentValue = await selector.InputValueAsync();
+
+        var options = Page.Locator("#connector-select option:not(:disabled)");
+        var count = await options.CountAsync();
+
+        if (count < 2) return;
+
+        string? targetValue = null;
+        for (int i = 0; i < count; i++)
+        {
+            var value = await options.Nth(i).GetAttributeAsync("value");
+            if (value != currentValue)
+            {
+                targetValue = value;
+                break;
+            }
+        }
+
+        if (targetValue == null) return;
+
+        // Act - Start watching for spinner before switching
+        var spinnerTask = loadingSpinner.WaitForAsync(new() { State = WaitForSelectorState.Visible, Timeout = TimeoutMs });
+
+        await selector.SelectOptionAsync(targetValue);
+
+        // Assert - Spinner should appear (might be very quick)
+        // If spinner doesn't appear within timeout, the switch was too fast - that's OK
+        try
+        {
+            await spinnerTask;
+        }
+        catch (TimeoutException)
+        {
+            // Switching was too fast to catch spinner, which is acceptable
+        }
+
+        // After switch completes, spinner should be hidden
+        await Page.WaitForFunctionAsync(
+            "() => !document.querySelector('.loading-spinner') || document.querySelector('.loading-spinner').style.display === 'none' || !document.querySelector('.loading-spinner').offsetParent",
+            options: new() { Timeout = TimeoutMs }
+        );
+    }
+
+    [Trait("Category", "IntegrationTest")]
+    [Trait("Category", "UI")]
+    [Trait("Category", "LLMRequired")]
+    [Fact]
+    public async Task Given_Connector_When_Switched_Then_Selector_Should_Show_New_Value()
+    {
+        // Arrange
+        var selector = Page.Locator("#connector-select");
+
+        var currentValue = await selector.InputValueAsync();
+
+        var options = Page.Locator("#connector-select option:not(:disabled)");
+        var count = await options.CountAsync();
+
+        if (count < 2) return;
+
+        string? targetValue = null;
+        for (int i = 0; i < count; i++)
+        {
+            var value = await options.Nth(i).GetAttributeAsync("value");
+            if (value != currentValue)
+            {
+                targetValue = value;
+                break;
+            }
+        }
+
+        if (targetValue == null) return;
+
+        // Act
+        await selector.SelectOptionAsync(targetValue);
+
+        // Wait for switch to complete
+        await Page.WaitForFunctionAsync(
+            "() => !document.querySelector('#connector-select').disabled",
+            options: new() { Timeout = TimeoutMs }
+        );
+
+        // Assert
+        var newValue = await selector.InputValueAsync();
+        newValue.ShouldBe(targetValue);
+    }
+
+    public override async Task DisposeAsync()
+    {
+        await Page.CloseAsync();
+        await base.DisposeAsync();
+    }
+}

--- a/test/OpenChat.PlaygroundApp.Tests/Connectors/FoundryLocalConnectorTests.cs
+++ b/test/OpenChat.PlaygroundApp.Tests/Connectors/FoundryLocalConnectorTests.cs
@@ -1,3 +1,4 @@
+using Microsoft.AI.Foundry.Local;
 using Microsoft.Extensions.AI;
 
 using OpenChat.PlaygroundApp.Abstractions;
@@ -9,7 +10,7 @@ namespace OpenChat.PlaygroundApp.Tests.Connectors;
 public class FoundryLocalConnectorTests
 {
     private const string Alias = "phi-4-mini";
-    private const string ServiceUrl = "http://localhost:55588";
+    private const string ServiceUrl = "http://localhost:52230";
 
     private static AppSettings BuildAppSettings(string? serviceUrl = ServiceUrl, string? alias = Alias)
     {
@@ -200,10 +201,10 @@ public class FoundryLocalConnectorTests
     [Trait("Category", "IgnoreGitHubActions")]
     [Theory]
     [InlineData(null, typeof(NullReferenceException), "Object reference not set to an instance of an object")]
-    [InlineData("", typeof(InvalidOperationException), "Model not found")]
-    [InlineData("   ", typeof(InvalidOperationException), "Model not found")]
-    [InlineData("\t\r\n", typeof(InvalidOperationException), "Model not found")]
-    [InlineData("not-a-model", typeof(InvalidOperationException), "Model not found")]
+    [InlineData("", typeof(FoundryLocalException), "not found")]
+    [InlineData("   ", typeof(FoundryLocalException), "not found")]
+    [InlineData("\t\r\n", typeof(FoundryLocalException), "not found")]
+    [InlineData("not-a-model", typeof(FoundryLocalException), "not found")]
     public void Given_Invalid_Alias_When_GetChatClient_Invoked_Then_It_Should_Throw(string? alias, Type expected, string message)
     {
         // Arrange

--- a/test/OpenChat.PlaygroundApp.Tests/Endpoints/EndpointExtensionsTests.cs
+++ b/test/OpenChat.PlaygroundApp.Tests/Endpoints/EndpointExtensionsTests.cs
@@ -4,6 +4,7 @@ using Microsoft.AspNetCore.Builder;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
 
+using OpenChat.PlaygroundApp.Abstractions;
 using OpenChat.PlaygroundApp.Endpoints;
 using OpenChat.PlaygroundApp.Services;
 
@@ -148,10 +149,14 @@ public partial class EndpointExtensionsTests
         // Arrange
         var builder = WebApplication.CreateBuilder();
         var chatService = Substitute.For<IChatService>();
+        var chatClientFactory = Substitute.For<IChatClientFactory>();
         var logger = Substitute.For<ILogger<ChatResponseEndpoint>>();
-        
+        var connectorLogger = Substitute.For<ILogger<ConnectorEndpoint>>();
+
         builder.Services.AddSingleton(chatService);
+        builder.Services.AddSingleton(chatClientFactory);
         builder.Services.AddSingleton(logger);
+        builder.Services.AddSingleton(connectorLogger);
         builder.Services.AddEndpoints(typeof(ChatResponseEndpoint).Assembly);
         var app = builder.Build();
 
@@ -170,10 +175,14 @@ public partial class EndpointExtensionsTests
         // Arrange
         var builder = WebApplication.CreateBuilder();
         var chatService = Substitute.For<IChatService>();
+        var chatClientFactory = Substitute.For<IChatClientFactory>();
         var logger = Substitute.For<ILogger<ChatResponseEndpoint>>();
-        
+        var connectorLogger = Substitute.For<ILogger<ConnectorEndpoint>>();
+
         builder.Services.AddSingleton(chatService);
+        builder.Services.AddSingleton(chatClientFactory);
         builder.Services.AddSingleton(logger);
+        builder.Services.AddSingleton(connectorLogger);
         builder.Services.AddEndpoints(typeof(ChatResponseEndpoint).Assembly);
         var app = builder.Build();
         var group = app.MapGroup("/api");

--- a/test/OpenChat.PlaygroundApp.Tests/Services/ChatClientFactoryTests.cs
+++ b/test/OpenChat.PlaygroundApp.Tests/Services/ChatClientFactoryTests.cs
@@ -1,0 +1,740 @@
+using Microsoft.Extensions.AI;
+using Microsoft.Extensions.Logging;
+
+using OpenChat.PlaygroundApp.Configurations;
+using OpenChat.PlaygroundApp.Connectors;
+using OpenChat.PlaygroundApp.Services;
+
+namespace OpenChat.PlaygroundApp.Tests.Services;
+
+public class ChatClientFactoryTests
+{
+    #region Constructor Tests
+
+    [Trait("Category", "UnitTest")]
+    [Fact]
+    public void Given_Null_Settings_When_Instantiated_Then_It_Should_Throw()
+    {
+        // Arrange
+        var loggerFactory = Substitute.For<ILoggerFactory>();
+        var logger = Substitute.For<ILogger<ChatClientFactory>>();
+
+        // Act
+        Action action = () => new ChatClientFactory(null!, loggerFactory, logger);
+
+        // Assert
+        action.ShouldThrow<ArgumentNullException>()
+              .ParamName.ShouldBe("settings");
+    }
+
+    [Trait("Category", "UnitTest")]
+    [Fact]
+    public void Given_Null_LoggerFactory_When_Instantiated_Then_It_Should_Throw()
+    {
+        // Arrange
+        var settings = new AppSettings();
+        var logger = Substitute.For<ILogger<ChatClientFactory>>();
+
+        // Act
+        Action action = () => new ChatClientFactory(settings, null!, logger);
+
+        // Assert
+        action.ShouldThrow<ArgumentNullException>()
+              .ParamName.ShouldBe("loggerFactory");
+    }
+
+    [Trait("Category", "UnitTest")]
+    [Fact]
+    public void Given_Null_Logger_When_Instantiated_Then_It_Should_Throw()
+    {
+        // Arrange
+        var settings = new AppSettings();
+        var loggerFactory = Substitute.For<ILoggerFactory>();
+
+        // Act
+        Action action = () => new ChatClientFactory(settings, loggerFactory, null!);
+
+        // Assert
+        action.ShouldThrow<ArgumentNullException>()
+              .ParamName.ShouldBe("logger");
+    }
+
+    [Trait("Category", "UnitTest")]
+    [Fact]
+    public void Given_Valid_Dependencies_When_Instantiated_Then_It_Should_Create()
+    {
+        // Arrange
+        var settings = new AppSettings();
+        var loggerFactory = Substitute.For<ILoggerFactory>();
+        var logger = Substitute.For<ILogger<ChatClientFactory>>();
+
+        // Act
+        var factory = new ChatClientFactory(settings, loggerFactory, logger);
+
+        // Assert
+        factory.ShouldNotBeNull();
+    }
+
+    #endregion
+
+    #region StartAsync Tests
+
+    [Trait("Category", "UnitTest")]
+    [Fact]
+    public async Task Given_Factory_When_StartAsync_Called_Then_It_Should_Return_Immediately()
+    {
+        // Arrange
+        var settings = new AppSettings();
+        var loggerFactory = Substitute.For<ILoggerFactory>();
+        var logger = Substitute.For<ILogger<ChatClientFactory>>();
+        var factory = new ChatClientFactory(settings, loggerFactory, logger);
+
+        // Act
+        var task = factory.StartAsync(CancellationToken.None);
+
+        // Assert - Should complete immediately (non-blocking)
+        task.IsCompleted.ShouldBeTrue();
+        await task;
+    }
+
+    [Trait("Category", "UnitTest")]
+    [Fact]
+    public async Task Given_Configured_Ollama_When_StartAsync_Then_State_Should_Eventually_Be_Ready()
+    {
+        // Arrange
+        var settings = new AppSettings
+        {
+            Ollama = new OllamaSettings { BaseUrl = "http://localhost:11434" }
+        };
+        var loggerFactory = Substitute.For<ILoggerFactory>();
+        var logger = Substitute.For<ILogger<ChatClientFactory>>();
+        var factory = new ChatClientFactory(settings, loggerFactory, logger);
+
+        // Act
+        await factory.StartAsync(CancellationToken.None);
+
+        // Wait for background validation to complete
+        await Task.Delay(100);
+
+        // Assert
+        var state = factory.GetConnectorState(ConnectorType.Ollama);
+        state.ShouldBe(ConnectorState.Ready);
+    }
+
+    [Trait("Category", "UnitTest")]
+    [Fact]
+    public async Task Given_NotConfigured_Ollama_When_StartAsync_Then_State_Should_Eventually_Be_NotConfigured()
+    {
+        // Arrange
+        var settings = new AppSettings
+        {
+            Ollama = null
+        };
+        var loggerFactory = Substitute.For<ILoggerFactory>();
+        var logger = Substitute.For<ILogger<ChatClientFactory>>();
+        var factory = new ChatClientFactory(settings, loggerFactory, logger);
+
+        // Act
+        await factory.StartAsync(CancellationToken.None);
+
+        // Wait for background validation to complete
+        await Task.Delay(100);
+
+        // Assert
+        var state = factory.GetConnectorState(ConnectorType.Ollama);
+        state.ShouldBe(ConnectorState.NotConfigured);
+    }
+
+    #endregion
+
+    #region StopAsync Tests
+
+    [Trait("Category", "UnitTest")]
+    [Fact]
+    public async Task Given_Factory_When_StopAsync_Called_Then_It_Should_Complete()
+    {
+        // Arrange
+        var settings = new AppSettings();
+        var loggerFactory = Substitute.For<ILoggerFactory>();
+        var logger = Substitute.For<ILogger<ChatClientFactory>>();
+        var factory = new ChatClientFactory(settings, loggerFactory, logger);
+
+        // Act
+        await factory.StopAsync(CancellationToken.None);
+
+        // Assert - Should complete without error
+        true.ShouldBeTrue();
+    }
+
+    #endregion
+
+    #region GetConnectorState Tests
+
+    [Trait("Category", "UnitTest")]
+    [Fact]
+    public void Given_Unknown_Connector_When_GetConnectorState_Called_Then_It_Should_Return_NotConfigured()
+    {
+        // Arrange
+        var settings = new AppSettings();
+        var loggerFactory = Substitute.For<ILoggerFactory>();
+        var logger = Substitute.For<ILogger<ChatClientFactory>>();
+        var factory = new ChatClientFactory(settings, loggerFactory, logger);
+
+        // Act
+        var state = factory.GetConnectorState(ConnectorType.Unknown);
+
+        // Assert
+        state.ShouldBe(ConnectorState.NotConfigured);
+    }
+
+    [Trait("Category", "UnitTest")]
+    [Fact]
+    public void Given_Unvalidated_Connector_When_GetConnectorState_Called_Then_It_Should_Return_NotConfigured()
+    {
+        // Arrange
+        var settings = new AppSettings();
+        var loggerFactory = Substitute.For<ILoggerFactory>();
+        var logger = Substitute.For<ILogger<ChatClientFactory>>();
+        var factory = new ChatClientFactory(settings, loggerFactory, logger);
+
+        // Act - Without calling StartAsync
+        var state = factory.GetConnectorState(ConnectorType.Ollama);
+
+        // Assert
+        state.ShouldBe(ConnectorState.NotConfigured);
+    }
+
+    #endregion
+
+    #region GetConnectorError Tests
+
+    [Trait("Category", "UnitTest")]
+    [Fact]
+    public void Given_NoError_When_GetConnectorError_Called_Then_It_Should_Return_Null()
+    {
+        // Arrange
+        var settings = new AppSettings();
+        var loggerFactory = Substitute.For<ILoggerFactory>();
+        var logger = Substitute.For<ILogger<ChatClientFactory>>();
+        var factory = new ChatClientFactory(settings, loggerFactory, logger);
+
+        // Act
+        var error = factory.GetConnectorError(ConnectorType.Ollama);
+
+        // Assert
+        error.ShouldBeNull();
+    }
+
+    [Trait("Category", "UnitTest")]
+    [Fact]
+    public async Task Given_NotConfigured_Connector_When_GetConnectorError_Called_Then_It_Should_Return_Message()
+    {
+        // Arrange
+        var settings = new AppSettings { Ollama = null };
+        var loggerFactory = Substitute.For<ILoggerFactory>();
+        var logger = Substitute.For<ILogger<ChatClientFactory>>();
+        var factory = new ChatClientFactory(settings, loggerFactory, logger);
+
+        await factory.StartAsync(CancellationToken.None);
+        await Task.Delay(100);
+
+        // Act
+        var error = factory.GetConnectorError(ConnectorType.Ollama);
+
+        // Assert
+        error.ShouldNotBeNull();
+        error.ShouldContain("not configured");
+    }
+
+    #endregion
+
+    #region GetCachedChatClient Tests
+
+    [Trait("Category", "UnitTest")]
+    [Fact]
+    public void Given_NoCache_When_GetCachedChatClient_Called_Then_It_Should_Return_Null()
+    {
+        // Arrange
+        var settings = new AppSettings();
+        var loggerFactory = Substitute.For<ILoggerFactory>();
+        var logger = Substitute.For<ILogger<ChatClientFactory>>();
+        var factory = new ChatClientFactory(settings, loggerFactory, logger);
+
+        // Act
+        var client = factory.GetCachedChatClient(ConnectorType.Ollama);
+
+        // Assert
+        client.ShouldBeNull();
+    }
+
+    #endregion
+
+    #region GetAllConnectors Tests
+
+    [Trait("Category", "UnitTest")]
+    [Fact]
+    public void Given_Factory_When_GetAllConnectors_Called_Then_It_Should_Return_All_NonUnknown_Connectors()
+    {
+        // Arrange
+        var settings = new AppSettings();
+        var loggerFactory = Substitute.For<ILoggerFactory>();
+        var logger = Substitute.For<ILogger<ChatClientFactory>>();
+        var factory = new ChatClientFactory(settings, loggerFactory, logger);
+
+        // Act
+        var connectors = factory.GetAllConnectors().ToList();
+
+        // Assert
+        connectors.ShouldNotBeEmpty();
+        connectors.ShouldNotContain(c => c.Type == ConnectorType.Unknown);
+
+        // Should include all defined connector types except Unknown
+        var expectedCount = Enum.GetValues<ConnectorType>().Count(t => t != ConnectorType.Unknown);
+        connectors.Count.ShouldBe(expectedCount);
+    }
+
+    [Trait("Category", "UnitTest")]
+    [Fact]
+    public void Given_Factory_When_GetAllConnectors_Called_Then_Each_Should_Have_Name()
+    {
+        // Arrange
+        var settings = new AppSettings();
+        var loggerFactory = Substitute.For<ILoggerFactory>();
+        var logger = Substitute.For<ILogger<ChatClientFactory>>();
+        var factory = new ChatClientFactory(settings, loggerFactory, logger);
+
+        // Act
+        var connectors = factory.GetAllConnectors().ToList();
+
+        // Assert
+        connectors.ShouldAllBe(c => !string.IsNullOrWhiteSpace(c.Name));
+    }
+
+    #endregion
+
+    #region GetAvailableConnectors Tests
+
+    [Trait("Category", "UnitTest")]
+    [Fact]
+    public async Task Given_NoConfiguredConnectors_When_GetAvailableConnectors_Called_Then_It_Should_Return_Empty()
+    {
+        // Arrange
+        var settings = new AppSettings();
+        var loggerFactory = Substitute.For<ILoggerFactory>();
+        var logger = Substitute.For<ILogger<ChatClientFactory>>();
+        var factory = new ChatClientFactory(settings, loggerFactory, logger);
+
+        await factory.StartAsync(CancellationToken.None);
+        await Task.Delay(100);
+
+        // Act
+        var connectors = factory.GetAvailableConnectors().ToList();
+
+        // Assert
+        connectors.ShouldBeEmpty();
+    }
+
+    [Trait("Category", "UnitTest")]
+    [Fact]
+    public async Task Given_ConfiguredOllama_When_GetAvailableConnectors_Called_Then_It_Should_Return_Ollama()
+    {
+        // Arrange
+        var settings = new AppSettings
+        {
+            Ollama = new OllamaSettings { BaseUrl = "http://localhost:11434" }
+        };
+        var loggerFactory = Substitute.For<ILoggerFactory>();
+        var logger = Substitute.For<ILogger<ChatClientFactory>>();
+        var factory = new ChatClientFactory(settings, loggerFactory, logger);
+
+        await factory.StartAsync(CancellationToken.None);
+        await Task.Delay(100);
+
+        // Act
+        var connectors = factory.GetAvailableConnectors().ToList();
+
+        // Assert
+        connectors.ShouldContain(c => c.Type == ConnectorType.Ollama);
+    }
+
+    [Trait("Category", "UnitTest")]
+    [Fact]
+    public async Task Given_MultipleConfiguredConnectors_When_GetAvailableConnectors_Called_Then_It_Should_Return_All()
+    {
+        // Arrange
+        var settings = new AppSettings
+        {
+            Ollama = new OllamaSettings { BaseUrl = "http://localhost:11434" },
+            OpenAI = new OpenAISettings { ApiKey = "test-key" }
+        };
+        var loggerFactory = Substitute.For<ILoggerFactory>();
+        var logger = Substitute.For<ILogger<ChatClientFactory>>();
+        var factory = new ChatClientFactory(settings, loggerFactory, logger);
+
+        await factory.StartAsync(CancellationToken.None);
+        await Task.Delay(100);
+
+        // Act
+        var connectors = factory.GetAvailableConnectors().ToList();
+
+        // Assert
+        connectors.Count.ShouldBeGreaterThanOrEqualTo(2);
+        connectors.ShouldContain(c => c.Type == ConnectorType.Ollama);
+        connectors.ShouldContain(c => c.Type == ConnectorType.OpenAI);
+    }
+
+    #endregion
+
+    #region GetOrCreateChatClientAsync Tests
+
+    [Trait("Category", "UnitTest")]
+    [Fact]
+    public async Task Given_NotConfigured_Connector_When_GetOrCreateChatClientAsync_Called_Then_It_Should_Throw()
+    {
+        // Arrange
+        var settings = new AppSettings { Ollama = null };
+        var loggerFactory = Substitute.For<ILoggerFactory>();
+        var logger = Substitute.For<ILogger<ChatClientFactory>>();
+        var factory = new ChatClientFactory(settings, loggerFactory, logger);
+
+        await factory.StartAsync(CancellationToken.None);
+        await Task.Delay(100);
+
+        // Act
+        Func<Task> action = () => factory.GetOrCreateChatClientAsync(ConnectorType.Ollama);
+
+        // Assert
+        await action.ShouldThrowAsync<InvalidOperationException>();
+    }
+
+    [Trait("Category", "IntegrationTest")]
+    [Trait("Category", "LLMRequired")]
+    [Fact]
+    public async Task Given_Configured_Ollama_When_GetOrCreateChatClientAsync_Called_Then_It_Should_Return_Client()
+    {
+        // Arrange
+        var settings = new AppSettings
+        {
+            Ollama = new OllamaSettings
+            {
+                BaseUrl = "http://localhost:11434",
+                Model = "hf.co/Qwen/Qwen3-0.6B-GGUF"
+            }
+        };
+        var loggerFactory = Substitute.For<ILoggerFactory>();
+        loggerFactory.CreateLogger(Arg.Any<string>()).Returns(Substitute.For<ILogger>());
+        var logger = Substitute.For<ILogger<ChatClientFactory>>();
+        var factory = new ChatClientFactory(settings, loggerFactory, logger);
+
+        await factory.StartAsync(CancellationToken.None);
+        await Task.Delay(100);
+
+        // Act
+        var client = await factory.GetOrCreateChatClientAsync(ConnectorType.Ollama);
+
+        // Assert
+        client.ShouldNotBeNull();
+        client.ShouldBeAssignableTo<IChatClient>();
+    }
+
+    [Trait("Category", "IntegrationTest")]
+    [Trait("Category", "LLMRequired")]
+    [Fact]
+    public async Task Given_Client_Already_Cached_When_GetOrCreateChatClientAsync_Called_Then_It_Should_Return_Same_Instance()
+    {
+        // Arrange
+        var settings = new AppSettings
+        {
+            Ollama = new OllamaSettings
+            {
+                BaseUrl = "http://localhost:11434",
+                Model = "hf.co/Qwen/Qwen3-0.6B-GGUF"
+            }
+        };
+        var loggerFactory = Substitute.For<ILoggerFactory>();
+        loggerFactory.CreateLogger(Arg.Any<string>()).Returns(Substitute.For<ILogger>());
+        var logger = Substitute.For<ILogger<ChatClientFactory>>();
+        var factory = new ChatClientFactory(settings, loggerFactory, logger);
+
+        await factory.StartAsync(CancellationToken.None);
+        await Task.Delay(100);
+
+        // Act
+        var client1 = await factory.GetOrCreateChatClientAsync(ConnectorType.Ollama);
+        var client2 = await factory.GetOrCreateChatClientAsync(ConnectorType.Ollama);
+
+        // Assert
+        client1.ShouldBeSameAs(client2);
+    }
+
+    [Trait("Category", "IntegrationTest")]
+    [Trait("Category", "LLMRequired")]
+    [Fact]
+    public async Task Given_Client_Created_When_GetCachedChatClient_Called_Then_It_Should_Return_Client()
+    {
+        // Arrange
+        var settings = new AppSettings
+        {
+            Ollama = new OllamaSettings
+            {
+                BaseUrl = "http://localhost:11434",
+                Model = "hf.co/Qwen/Qwen3-0.6B-GGUF"
+            }
+        };
+        var loggerFactory = Substitute.For<ILoggerFactory>();
+        loggerFactory.CreateLogger(Arg.Any<string>()).Returns(Substitute.For<ILogger>());
+        var logger = Substitute.For<ILogger<ChatClientFactory>>();
+        var factory = new ChatClientFactory(settings, loggerFactory, logger);
+
+        await factory.StartAsync(CancellationToken.None);
+        await Task.Delay(100);
+
+        var created = await factory.GetOrCreateChatClientAsync(ConnectorType.Ollama);
+
+        // Act
+        var cached = factory.GetCachedChatClient(ConnectorType.Ollama);
+
+        // Assert
+        cached.ShouldNotBeNull();
+        cached.ShouldBeSameAs(created);
+    }
+
+    [Trait("Category", "IntegrationTest")]
+    [Trait("Category", "LLMRequired")]
+    [Fact]
+    public async Task Given_Client_Created_When_GetConnectorState_Called_Then_It_Should_Return_Active()
+    {
+        // Arrange
+        var settings = new AppSettings
+        {
+            Ollama = new OllamaSettings
+            {
+                BaseUrl = "http://localhost:11434",
+                Model = "hf.co/Qwen/Qwen3-0.6B-GGUF"
+            }
+        };
+        var loggerFactory = Substitute.For<ILoggerFactory>();
+        loggerFactory.CreateLogger(Arg.Any<string>()).Returns(Substitute.For<ILogger>());
+        var logger = Substitute.For<ILogger<ChatClientFactory>>();
+        var factory = new ChatClientFactory(settings, loggerFactory, logger);
+
+        await factory.StartAsync(CancellationToken.None);
+        await Task.Delay(100);
+
+        await factory.GetOrCreateChatClientAsync(ConnectorType.Ollama);
+
+        // Act
+        var state = factory.GetConnectorState(ConnectorType.Ollama);
+
+        // Assert
+        state.ShouldBe(ConnectorState.Active);
+    }
+
+    #endregion
+
+    #region Concurrent Access Tests
+
+    [Trait("Category", "UnitTest")]
+    [Fact]
+    public async Task Given_ConcurrentRequests_When_GetOrCreateChatClientAsync_Called_Then_Only_One_Should_Create()
+    {
+        // Arrange - Use a connector that will fail (to avoid actual LLM call)
+        var settings = new AppSettings
+        {
+            Ollama = new OllamaSettings
+            {
+                BaseUrl = "http://invalid-host:11434",
+                Model = "test-model"
+            }
+        };
+        var loggerFactory = Substitute.For<ILoggerFactory>();
+        loggerFactory.CreateLogger(Arg.Any<string>()).Returns(Substitute.For<ILogger>());
+        var logger = Substitute.For<ILogger<ChatClientFactory>>();
+        var factory = new ChatClientFactory(settings, loggerFactory, logger);
+
+        await factory.StartAsync(CancellationToken.None);
+        await Task.Delay(100);
+
+        // Act - Fire multiple concurrent requests
+        var tasks = Enumerable.Range(0, 5)
+            .Select(_ => Task.Run(async () =>
+            {
+                try
+                {
+                    await factory.GetOrCreateChatClientAsync(ConnectorType.Ollama);
+                }
+                catch
+                {
+                    // Expected to fail due to invalid host
+                }
+            }))
+            .ToList();
+
+        await Task.WhenAll(tasks);
+
+        // Assert - State should be Failed (only one creation attempt due to lock)
+        var state = factory.GetConnectorState(ConnectorType.Ollama);
+        state.ShouldBe(ConnectorState.Failed);
+    }
+
+    #endregion
+
+    #region Validation Settings Tests
+
+    [Trait("Category", "UnitTest")]
+    [Theory]
+    [InlineData(null, ConnectorState.NotConfigured)]
+    [InlineData("", ConnectorState.NotConfigured)]
+    [InlineData("   ", ConnectorState.NotConfigured)]
+    [InlineData("http://localhost:11434", ConnectorState.Ready)]
+    public async Task Given_OllamaBaseUrl_When_StartAsync_Called_Then_State_Should_Match(string? baseUrl, ConnectorState expectedState)
+    {
+        // Arrange
+        var settings = new AppSettings
+        {
+            Ollama = baseUrl == null ? null : new OllamaSettings { BaseUrl = baseUrl }
+        };
+        var loggerFactory = Substitute.For<ILoggerFactory>();
+        var logger = Substitute.For<ILogger<ChatClientFactory>>();
+        var factory = new ChatClientFactory(settings, loggerFactory, logger);
+
+        // Act
+        await factory.StartAsync(CancellationToken.None);
+        await Task.Delay(100);
+
+        // Assert
+        var state = factory.GetConnectorState(ConnectorType.Ollama);
+        state.ShouldBe(expectedState);
+    }
+
+    [Trait("Category", "UnitTest")]
+    [Theory]
+    [InlineData(null, ConnectorState.NotConfigured)]
+    [InlineData("", ConnectorState.NotConfigured)]
+    [InlineData("sk-test-key", ConnectorState.Ready)]
+    public async Task Given_OpenAIApiKey_When_StartAsync_Called_Then_State_Should_Match(string? apiKey, ConnectorState expectedState)
+    {
+        // Arrange
+        var settings = new AppSettings
+        {
+            OpenAI = apiKey == null ? null : new OpenAISettings { ApiKey = apiKey }
+        };
+        var loggerFactory = Substitute.For<ILoggerFactory>();
+        var logger = Substitute.For<ILogger<ChatClientFactory>>();
+        var factory = new ChatClientFactory(settings, loggerFactory, logger);
+
+        // Act
+        await factory.StartAsync(CancellationToken.None);
+        await Task.Delay(100);
+
+        // Assert
+        var state = factory.GetConnectorState(ConnectorType.OpenAI);
+        state.ShouldBe(expectedState);
+    }
+
+    [Trait("Category", "UnitTest")]
+    [Fact]
+    public async Task Given_AzureAIFoundry_With_Both_Settings_When_StartAsync_Called_Then_State_Should_Be_Ready()
+    {
+        // Arrange
+        var settings = new AppSettings
+        {
+            AzureAIFoundry = new AzureAIFoundrySettings
+            {
+                Endpoint = "https://test.openai.azure.com",
+                ApiKey = "test-key"
+            }
+        };
+        var loggerFactory = Substitute.For<ILoggerFactory>();
+        var logger = Substitute.For<ILogger<ChatClientFactory>>();
+        var factory = new ChatClientFactory(settings, loggerFactory, logger);
+
+        // Act
+        await factory.StartAsync(CancellationToken.None);
+        await Task.Delay(100);
+
+        // Assert
+        var state = factory.GetConnectorState(ConnectorType.AzureAIFoundry);
+        state.ShouldBe(ConnectorState.Ready);
+    }
+
+    [Trait("Category", "UnitTest")]
+    [Fact]
+    public async Task Given_AzureAIFoundry_Missing_ApiKey_When_StartAsync_Called_Then_State_Should_Be_NotConfigured()
+    {
+        // Arrange
+        var settings = new AppSettings
+        {
+            AzureAIFoundry = new AzureAIFoundrySettings
+            {
+                Endpoint = "https://test.openai.azure.com",
+                ApiKey = null  // Missing
+            }
+        };
+        var loggerFactory = Substitute.For<ILoggerFactory>();
+        var logger = Substitute.For<ILogger<ChatClientFactory>>();
+        var factory = new ChatClientFactory(settings, loggerFactory, logger);
+
+        // Act
+        await factory.StartAsync(CancellationToken.None);
+        await Task.Delay(100);
+
+        // Assert
+        var state = factory.GetConnectorState(ConnectorType.AzureAIFoundry);
+        state.ShouldBe(ConnectorState.NotConfigured);
+    }
+
+    [Trait("Category", "UnitTest")]
+    [Fact]
+    public async Task Given_AmazonBedrock_With_All_Settings_When_StartAsync_Called_Then_State_Should_Be_Ready()
+    {
+        // Arrange
+        var settings = new AppSettings
+        {
+            AmazonBedrock = new AmazonBedrockSettings
+            {
+                AccessKeyId = "test-access-key",
+                SecretAccessKey = "test-secret",
+                Region = "us-east-1"
+            }
+        };
+        var loggerFactory = Substitute.For<ILoggerFactory>();
+        var logger = Substitute.For<ILogger<ChatClientFactory>>();
+        var factory = new ChatClientFactory(settings, loggerFactory, logger);
+
+        // Act
+        await factory.StartAsync(CancellationToken.None);
+        await Task.Delay(100);
+
+        // Assert
+        var state = factory.GetConnectorState(ConnectorType.AmazonBedrock);
+        state.ShouldBe(ConnectorState.Ready);
+    }
+
+    [Trait("Category", "UnitTest")]
+    [Fact]
+    public async Task Given_FoundryLocal_With_ServiceUrl_When_StartAsync_Called_Then_State_Should_Be_Ready()
+    {
+        // Arrange
+        var settings = new AppSettings
+        {
+            FoundryLocal = new FoundryLocalSettings
+            {
+                ServiceUrl = "http://localhost:52230"
+            }
+        };
+        var loggerFactory = Substitute.For<ILoggerFactory>();
+        var logger = Substitute.For<ILogger<ChatClientFactory>>();
+        var factory = new ChatClientFactory(settings, loggerFactory, logger);
+
+        // Act
+        await factory.StartAsync(CancellationToken.None);
+        await Task.Delay(100);
+
+        // Assert
+        var state = factory.GetConnectorState(ConnectorType.FoundryLocal);
+        state.ShouldBe(ConnectorState.Ready);
+    }
+
+    #endregion
+}

--- a/test/OpenChat.PlaygroundApp.Tests/Services/ChatServiceTests.cs
+++ b/test/OpenChat.PlaygroundApp.Tests/Services/ChatServiceTests.cs
@@ -1,6 +1,8 @@
 using Microsoft.Extensions.AI;
 using Microsoft.Extensions.Logging;
 
+using OpenChat.PlaygroundApp.Abstractions;
+using OpenChat.PlaygroundApp.Connectors;
 using OpenChat.PlaygroundApp.Services;
 
 namespace OpenChat.PlaygroundApp.Tests.Services;
@@ -9,13 +11,13 @@ public class ChatServiceTests
 {
     [Trait("Category", "UnitTest")]
     [Fact]
-    public void Given_Null_IChatClient_When_ChatService_Instantiated_Then_It_Should_Throw()
+    public void Given_Null_StateManager_When_ChatService_Instantiated_Then_It_Should_Throw()
     {
         // Arrange
         var logger = Substitute.For<ILogger<ChatService>>();
 
         // Act
-        Action action = () => new ChatService(default(IChatClient)!, logger);
+        Action action = () => new ChatService(default(IConnectorStateManager)!, logger);
 
         // Assert
         action.ShouldThrow<ArgumentNullException>();
@@ -26,10 +28,10 @@ public class ChatServiceTests
     public void Given_Null_Logger_When_ChatService_Instantiated_Then_It_Should_Throw()
     {
         // Arrange
-        var client = Substitute.For<IChatClient>();
+        var stateManager = Substitute.For<IConnectorStateManager>();
 
         // Act
-        Action action = () => new ChatService(client, default(ILogger<ChatService>)!);
+        Action action = () => new ChatService(stateManager, default(ILogger<ChatService>)!);
 
         // Assert
         action.ShouldThrow<ArgumentNullException>();
@@ -40,11 +42,11 @@ public class ChatServiceTests
     public void Given_Both_Dependencies_When_ChatService_Instantiated_Then_It_Should_Create()
     {
         // Arrange
-        var client = Substitute.For<IChatClient>();
+        var stateManager = Substitute.For<IConnectorStateManager>();
         var logger = Substitute.For<ILogger<ChatService>>();
 
         // Act
-        var result = new ChatService(client, logger);
+        var result = new ChatService(stateManager, logger);
 
         // Assert
         result.ShouldNotBeNull();
@@ -56,8 +58,12 @@ public class ChatServiceTests
     {
         // Arrange
         var chatClient = Substitute.For<IChatClient>();
+        var stateManager = Substitute.For<IConnectorStateManager>();
+        stateManager.CurrentChatClient.Returns(chatClient);
+        stateManager.CurrentConnectorType.Returns(ConnectorType.Ollama);
+
         var logger = Substitute.For<ILogger<ChatService>>();
-        var chatService = new ChatService(chatClient, logger);
+        var chatService = new ChatService(stateManager, logger);
 
         var messages = new List<ChatMessage>
         {
@@ -78,8 +84,12 @@ public class ChatServiceTests
     {
         // Arrange
         var chatClient = Substitute.For<IChatClient>();
+        var stateManager = Substitute.For<IConnectorStateManager>();
+        stateManager.CurrentChatClient.Returns(chatClient);
+        stateManager.CurrentConnectorType.Returns(ConnectorType.Ollama);
+
         var logger = Substitute.For<ILogger<ChatService>>();
-        var chatService = new ChatService(chatClient, logger);
+        var chatService = new ChatService(stateManager, logger);
 
         var messages = new List<ChatMessage>
         {
@@ -101,8 +111,12 @@ public class ChatServiceTests
     {
         // Arrange
         var chatClient = Substitute.For<IChatClient>();
+        var stateManager = Substitute.For<IConnectorStateManager>();
+        stateManager.CurrentChatClient.Returns(chatClient);
+        stateManager.CurrentConnectorType.Returns(ConnectorType.Ollama);
+
         var logger = Substitute.For<ILogger<ChatService>>();
-        var chatService = new ChatService(chatClient, logger);
+        var chatService = new ChatService(stateManager, logger);
 
         var messages = new List<ChatMessage>
         {
@@ -116,6 +130,32 @@ public class ChatServiceTests
         // Assert
         action.ShouldThrow<ArgumentException>()
               .Message.ShouldContain("The second message must be a user message");
+    }
+
+    [Trait("Category", "UnitTest")]
+    [Fact]
+    public void Given_Null_ChatClient_When_GetStreamingResponseAsync_Invoked_Then_It_Should_Throw()
+    {
+        // Arrange
+        var stateManager = Substitute.For<IConnectorStateManager>();
+        stateManager.CurrentChatClient.Returns((IChatClient?)null);
+        stateManager.CurrentConnectorType.Returns(ConnectorType.Unknown);
+
+        var logger = Substitute.For<ILogger<ChatService>>();
+        var chatService = new ChatService(stateManager, logger);
+
+        var messages = new List<ChatMessage>
+        {
+            new(ChatRole.System, "You are a helpful assistant."),
+            new(ChatRole.User, "Why is the sky blue?")
+        };
+
+        // Act
+        Action action = () => chatService.GetStreamingResponseAsync(messages);
+
+        // Assert
+        action.ShouldThrow<InvalidOperationException>()
+              .Message.ShouldContain("No chat client is currently initialized");
     }
 
     [Trait("Category", "UnitTest")]
@@ -133,8 +173,12 @@ public class ChatServiceTests
         chatClient.GetStreamingResponseAsync(Arg.Any<IEnumerable<ChatMessage>>(), Arg.Any<ChatOptions?>(), Arg.Any<CancellationToken>())
                   .Returns(responses.ToAsyncEnumerable());
 
+        var stateManager = Substitute.For<IConnectorStateManager>();
+        stateManager.CurrentChatClient.Returns(chatClient);
+        stateManager.CurrentConnectorType.Returns(ConnectorType.Ollama);
+
         var logger = Substitute.For<ILogger<ChatService>>();
-        var chatService = new ChatService(chatClient, logger);
+        var chatService = new ChatService(stateManager, logger);
 
         var messages = new List<ChatMessage>
         {

--- a/test/OpenChat.PlaygroundApp.Tests/Services/ChatServiceTests.cs
+++ b/test/OpenChat.PlaygroundApp.Tests/Services/ChatServiceTests.cs
@@ -159,6 +159,69 @@ public class ChatServiceTests
     }
 
     [Trait("Category", "UnitTest")]
+    [Fact]
+    public void Given_IsSwitching_True_When_GetStreamingResponseAsync_Invoked_Then_It_Should_Throw()
+    {
+        // Arrange
+        var chatClient = Substitute.For<IChatClient>();
+        var stateManager = Substitute.For<IConnectorStateManager>();
+        stateManager.CurrentChatClient.Returns(chatClient);
+        stateManager.CurrentConnectorType.Returns(ConnectorType.Ollama);
+        stateManager.IsSwitching.Returns(true);
+
+        var logger = Substitute.For<ILogger<ChatService>>();
+        var chatService = new ChatService(stateManager, logger);
+
+        var messages = new List<ChatMessage>
+        {
+            new(ChatRole.System, "You are a helpful assistant."),
+            new(ChatRole.User, "Why is the sky blue?")
+        };
+
+        // Act
+        Action action = () => chatService.GetStreamingResponseAsync(messages);
+
+        // Assert
+        action.ShouldThrow<InvalidOperationException>()
+              .Message.ShouldContain("Cannot send chat requests while connector is being switched");
+    }
+
+    [Trait("Category", "UnitTest")]
+    [Fact]
+    public async Task Given_IsSwitching_False_When_GetStreamingResponseAsync_Invoked_Then_It_Should_Proceed()
+    {
+        // Arrange
+        var responseMessages = new[] { "Hello, ", "how ", "can ", "I help?" };
+        IEnumerable<ChatResponseUpdate> responses = responseMessages.Select(m => new ChatResponseUpdate(ChatRole.Assistant, m));
+
+        var chatClient = Substitute.For<IChatClient>();
+        chatClient.GetStreamingResponseAsync(Arg.Any<IEnumerable<ChatMessage>>(), Arg.Any<ChatOptions?>(), Arg.Any<CancellationToken>())
+                  .Returns(responses.ToAsyncEnumerable());
+
+        var stateManager = Substitute.For<IConnectorStateManager>();
+        stateManager.CurrentChatClient.Returns(chatClient);
+        stateManager.CurrentConnectorType.Returns(ConnectorType.Ollama);
+        stateManager.IsSwitching.Returns(false);
+
+        var logger = Substitute.For<ILogger<ChatService>>();
+        var chatService = new ChatService(stateManager, logger);
+
+        var messages = new List<ChatMessage>
+        {
+            new(ChatRole.System, "You are a helpful assistant."),
+            new(ChatRole.User, "Hello")
+        };
+
+        // Act
+        var result = chatService.GetStreamingResponseAsync(messages);
+        var count = await result.CountAsync();
+
+        // Assert
+        result.ShouldNotBeNull();
+        count.ShouldBe(responseMessages.Length);
+    }
+
+    [Trait("Category", "UnitTest")]
     [Theory]
     [InlineData("This ")]
     [InlineData("This ", "is ")]

--- a/test/OpenChat.PlaygroundApp.Tests/Services/ConnectorStateManagerTests.cs
+++ b/test/OpenChat.PlaygroundApp.Tests/Services/ConnectorStateManagerTests.cs
@@ -1,0 +1,243 @@
+using Microsoft.Extensions.AI;
+using Microsoft.Extensions.Logging;
+
+using OpenChat.PlaygroundApp.Abstractions;
+using OpenChat.PlaygroundApp.Configurations;
+using OpenChat.PlaygroundApp.Connectors;
+using OpenChat.PlaygroundApp.Contracts;
+using OpenChat.PlaygroundApp.Services;
+
+namespace OpenChat.PlaygroundApp.Tests.Services;
+
+public class ConnectorStateManagerTests
+{
+    [Trait("Category", "UnitTest")]
+    [Fact]
+    public void Given_Null_Factory_When_ConnectorStateManager_Instantiated_Then_It_Should_Throw()
+    {
+        // Arrange
+        var settings = new AppSettings();
+        var logger = Substitute.For<ILogger<ConnectorStateManager>>();
+
+        // Act
+        Action action = () => new ConnectorStateManager(default(IChatClientFactory)!, settings, logger);
+
+        // Assert
+        action.ShouldThrow<ArgumentNullException>();
+    }
+
+    [Trait("Category", "UnitTest")]
+    [Fact]
+    public void Given_Null_Settings_When_ConnectorStateManager_Instantiated_Then_It_Should_Throw()
+    {
+        // Arrange
+        var factory = Substitute.For<IChatClientFactory>();
+        var logger = Substitute.For<ILogger<ConnectorStateManager>>();
+
+        // Act
+        Action action = () => new ConnectorStateManager(factory, default(AppSettings)!, logger);
+
+        // Assert
+        action.ShouldThrow<ArgumentNullException>();
+    }
+
+    [Trait("Category", "UnitTest")]
+    [Fact]
+    public void Given_Null_Logger_When_ConnectorStateManager_Instantiated_Then_It_Should_Throw()
+    {
+        // Arrange
+        var factory = Substitute.For<IChatClientFactory>();
+        var settings = new AppSettings();
+
+        // Act
+        Action action = () => new ConnectorStateManager(factory, settings, default(ILogger<ConnectorStateManager>)!);
+
+        // Assert
+        action.ShouldThrow<ArgumentNullException>();
+    }
+
+    [Trait("Category", "UnitTest")]
+    [Fact]
+    public void Given_All_Dependencies_When_ConnectorStateManager_Instantiated_Then_It_Should_Create()
+    {
+        // Arrange
+        var factory = Substitute.For<IChatClientFactory>();
+        var settings = new AppSettings();
+        var logger = Substitute.For<ILogger<ConnectorStateManager>>();
+
+        // Act
+        var result = new ConnectorStateManager(factory, settings, logger);
+
+        // Assert
+        result.ShouldNotBeNull();
+        result.IsSwitching.ShouldBeFalse();
+        result.CurrentConnectorType.ShouldBe(ConnectorType.Unknown);
+        result.CurrentChatClient.ShouldBeNull();
+    }
+
+    [Trait("Category", "UnitTest")]
+    [Fact]
+    public async Task Given_Valid_Connector_When_SwitchConnectorAsync_Called_Then_IsSwitching_Should_Be_True_During_Switch()
+    {
+        // Arrange
+        var chatClient = Substitute.For<IChatClient>();
+        var factory = Substitute.For<IChatClientFactory>();
+        factory.GetConnectorState(ConnectorType.Ollama).Returns(ConnectorState.Ready);
+
+        // Use TaskCompletionSource to control timing
+        var tcs = new TaskCompletionSource<IChatClient>();
+        factory.GetOrCreateChatClientAsync(ConnectorType.Ollama, Arg.Any<CancellationToken>())
+               .Returns(tcs.Task);
+
+        var settings = new AppSettings();
+        var logger = Substitute.For<ILogger<ConnectorStateManager>>();
+        var stateManager = new ConnectorStateManager(factory, settings, logger);
+
+        var switchingStates = new List<bool>();
+        stateManager.OnSwitchingStateChanged += (_, isSwitching) => switchingStates.Add(isSwitching);
+
+        // Act
+        var switchTask = stateManager.SwitchConnectorAsync(ConnectorType.Ollama);
+
+        // Assert - During switch
+        stateManager.IsSwitching.ShouldBeTrue();
+        switchingStates.ShouldContain(true);
+
+        // Complete the switch
+        tcs.SetResult(chatClient);
+        await switchTask;
+
+        // Assert - After switch
+        stateManager.IsSwitching.ShouldBeFalse();
+        switchingStates.ShouldContain(false);
+    }
+
+    [Trait("Category", "UnitTest")]
+    [Fact]
+    public async Task Given_Switch_Fails_When_SwitchConnectorAsync_Called_Then_IsSwitching_Should_Reset_To_False()
+    {
+        // Arrange
+        var factory = Substitute.For<IChatClientFactory>();
+        factory.GetConnectorState(ConnectorType.Ollama).Returns(ConnectorState.Ready);
+        factory.GetOrCreateChatClientAsync(ConnectorType.Ollama, Arg.Any<CancellationToken>())
+               .Returns<Task<IChatClient>>(_ => throw new InvalidOperationException("Connection failed"));
+
+        var settings = new AppSettings();
+        var logger = Substitute.For<ILogger<ConnectorStateManager>>();
+        var stateManager = new ConnectorStateManager(factory, settings, logger);
+
+        var switchingStates = new List<bool>();
+        stateManager.OnSwitchingStateChanged += (_, isSwitching) => switchingStates.Add(isSwitching);
+
+        // Act
+        Func<Task> action = () => stateManager.SwitchConnectorAsync(ConnectorType.Ollama);
+
+        // Assert
+        await action.ShouldThrowAsync<InvalidOperationException>();
+        stateManager.IsSwitching.ShouldBeFalse();
+        switchingStates.ShouldContain(true);
+        switchingStates.ShouldContain(false);
+    }
+
+    [Trait("Category", "UnitTest")]
+    [Fact]
+    public async Task Given_Same_Connector_When_SwitchConnectorAsync_Called_Then_It_Should_Skip_Switch()
+    {
+        // Arrange
+        var chatClient = Substitute.For<IChatClient>();
+        var factory = Substitute.For<IChatClientFactory>();
+        factory.GetConnectorState(ConnectorType.Ollama).Returns(ConnectorState.Ready);
+        factory.GetOrCreateChatClientAsync(ConnectorType.Ollama, Arg.Any<CancellationToken>())
+               .Returns(Task.FromResult(chatClient));
+
+        var settings = new AppSettings();
+        var logger = Substitute.For<ILogger<ConnectorStateManager>>();
+        var stateManager = new ConnectorStateManager(factory, settings, logger);
+
+        // First switch
+        await stateManager.SwitchConnectorAsync(ConnectorType.Ollama);
+
+        var switchingStates = new List<bool>();
+        stateManager.OnSwitchingStateChanged += (_, isSwitching) => switchingStates.Add(isSwitching);
+
+        // Act - Try to switch to same connector
+        await stateManager.SwitchConnectorAsync(ConnectorType.Ollama);
+
+        // Assert - No switching should have occurred
+        switchingStates.ShouldBeEmpty();
+    }
+
+    [Trait("Category", "UnitTest")]
+    [Fact]
+    public async Task Given_NotConfigured_Connector_When_SwitchConnectorAsync_Called_Then_It_Should_Throw()
+    {
+        // Arrange
+        var factory = Substitute.For<IChatClientFactory>();
+        factory.GetConnectorState(ConnectorType.OpenAI).Returns(ConnectorState.NotConfigured);
+
+        var settings = new AppSettings();
+        var logger = Substitute.For<ILogger<ConnectorStateManager>>();
+        var stateManager = new ConnectorStateManager(factory, settings, logger);
+
+        // Act
+        Func<Task> action = () => stateManager.SwitchConnectorAsync(ConnectorType.OpenAI);
+
+        // Assert
+        await action.ShouldThrowAsync<InvalidOperationException>();
+        stateManager.IsSwitching.ShouldBeFalse();
+    }
+
+    [Trait("Category", "UnitTest")]
+    [Fact]
+    public async Task Given_Valid_Switch_When_Completed_Then_OnConnectorChanged_Should_Be_Raised()
+    {
+        // Arrange
+        var chatClient = Substitute.For<IChatClient>();
+        var factory = Substitute.For<IChatClientFactory>();
+        factory.GetConnectorState(ConnectorType.Ollama).Returns(ConnectorState.Ready);
+        factory.GetOrCreateChatClientAsync(ConnectorType.Ollama, Arg.Any<CancellationToken>())
+               .Returns(Task.FromResult(chatClient));
+
+        var settings = new AppSettings();
+        var logger = Substitute.For<ILogger<ConnectorStateManager>>();
+        var stateManager = new ConnectorStateManager(factory, settings, logger);
+
+        ConnectorType? changedConnector = null;
+        stateManager.OnConnectorChanged += (_, type) => changedConnector = type;
+
+        // Act
+        await stateManager.SwitchConnectorAsync(ConnectorType.Ollama);
+
+        // Assert
+        changedConnector.ShouldBe(ConnectorType.Ollama);
+        stateManager.CurrentConnectorType.ShouldBe(ConnectorType.Ollama);
+        stateManager.CurrentChatClient.ShouldBe(chatClient);
+    }
+
+    [Trait("Category", "IntegrationTest")]
+    [Fact]
+    public async Task Given_EnsureInitializedAsync_Called_Twice_Then_It_Should_Only_Initialize_Once()
+    {
+        // Arrange
+        var chatClient = Substitute.For<IChatClient>();
+        var factory = Substitute.For<IChatClientFactory>();
+        factory.GetAvailableConnectors().Returns(new List<ConnectorInfo>
+        {
+            new(ConnectorType.Ollama, "Ollama", ConnectorState.Ready, null, false)
+        });
+        factory.GetConnectorState(ConnectorType.Ollama).Returns(ConnectorState.Ready);
+        factory.GetOrCreateChatClientAsync(ConnectorType.Ollama, Arg.Any<CancellationToken>())
+               .Returns(Task.FromResult(chatClient));
+
+        var settings = new AppSettings { ConnectorType = ConnectorType.Unknown };
+        var logger = Substitute.For<ILogger<ConnectorStateManager>>();
+        var stateManager = new ConnectorStateManager(factory, settings, logger);
+
+        // Act
+        await stateManager.EnsureInitializedAsync();
+        await stateManager.EnsureInitializedAsync();
+
+        // Assert - Should only be called once
+        await factory.Received(1).GetOrCreateChatClientAsync(ConnectorType.Ollama, Arg.Any<CancellationToken>());
+    }
+}


### PR DESCRIPTION
## Purpose
* 채팅 앱을 시작한 다음 Connector를 변경하는 기능 추가
* 여러 탭에서 서로 다른 Connector를 선택하여 사용 가능
* Connector 선택 드롭박스에 사용 가능여부 표시
  * 프로젝트 시작시 설정파일 존재여부 확인, 존재하지 않을 경우 Not Configured
  * Connector 선택시 의존성 인플레이팅, 실패할 경우 Failed 표시
  * Connector 선택 및 의존성 인플레이팅까지 모두 성공시 검은색 ● 표시

## Does this introduce a breaking change?
```
[ ] Yes
[x] No
```
> 

## Pull Request Type
```
[ ] Bugfix
[x] New feature
[ ] Refactoring (no functional changes, no api changes)
[ ] Documentation content changes
[ ] Other... Please describe:
```

## README updated?
```
[ ] Yes
[ ] No
[s] N/A
```

## How to Test
[README의 Integration tests ](https://github.com/tae0y/open-chat-playground/blob/main/README.md#integration-tests) 참고

## What to Check
* 여러 탭을 열어서 서로 다른 Connector를 선택하고 채
* 앱 시작후 Connector를 변경해서 채팅
* Connector 전환 중 채팅 입력 비활성화 확인
* Not Configured 상태의 커넥터 선택 불가 확인
* Failed 상태 커넥터의 에러 메시지 표시 확인

## Other Information
* Foundry Local은 다른 터미널에서 먼저 서비스를 기동해야 사용가능. 타임아웃 혹은 서비스 자동시작 기능의 문제로 추정됨. 이번 개발 범위는 아니므로 더 분석하지 않음.
* GitHub Models 인증토큰을 갱신하는 과정에서 User Secrets에 설정해둔구버전 토큰이 ASP.NET 컨벤션을 타고 AppSettings를 덮어씌우는 문제 있었음. 차후에는 설정 값을 불러올때 어떤 소스에서 가져온 것인지 표시해야겠음. 이 건은 백로그에 추가.
